### PR TITLE
Landing page name tweak

### DIFF
--- a/config/install/node.type.landing_page.yml
+++ b/config/install/node.type.landing_page.yml
@@ -10,7 +10,7 @@ third_party_settings:
     parent: 'main:'
 _core:
   default_config_hash: rqkAcyQ3zUUO1n3cxJUcHV6m46EgJZFvAchTzWeT5P4
-name: 'Landing Page'
+name: 'Landing page'
 type: landing_page
 description: 'A page created from various designed content sections.'
 help: ''


### PR DESCRIPTION
Adjusting the name of the landing page content type to ensure it's consistent with the basic page content type.