### PR TITLE
Placeholder text placement issue (on basic page content).

### DIFF
--- a/config/install/core.entity_form_display.node.page.default.yml
+++ b/config/install/core.entity_form_display.node.page.default.yml
@@ -95,7 +95,7 @@ content:
     weight: 11
     settings:
       rows: 5
-      placeholder: 'Defaults to the page title'
+      placeholder: ''
     third_party_settings: {  }
     type: string_textarea
     region: content
@@ -110,7 +110,7 @@ content:
     weight: 9
     settings:
       size: 60
-      placeholder: ''
+      placeholder: 'Defaults to the page title'
     third_party_settings: {  }
     type: string_textfield
     region: content


### PR DESCRIPTION
Moving the placeholder text within the teaser settings of the basic page content type to the teaser title from the caption field.