### PR TITLE
Resolve AJAX JS issue when navigating between pages.

### DIFF
--- a/themes/wilson_theme_starterkit/templates/navigation/pager.html.twig
+++ b/themes/wilson_theme_starterkit/templates/navigation/pager.html.twig
@@ -1,7 +1,7 @@
 {% if items %}
   <nav class="pager mt-16" role="navigation" aria-labelledby="{{ heading_id }}">
     <h4 id="{{ heading_id }}" class="visually-hidden">{{ 'Pagination'|t }}</h4>
-    <ul class="flex justify-center list-none p-0">
+    <ul class="flex justify-center list-none p-0 js-pager__items">
       {# Print first item if we are not on the first page. #}
       {% if items.first %}
         <li class="hidden lg:inline-block lg:mx-2 border border-primary focus:bg-primary hover:bg-primary hover:text-primary-contrast">


### PR DESCRIPTION
The class `js-pager__items` was missing from `pager.html.twig` in the Wilson theme preventing AJAX from triggering when trying to navigate between pages.