### PR TITLE
🙈 add local.settings.php to example gitignore file.

### DIFF
--- a/example-gitignore.txt
+++ b/example-gitignore.txt
@@ -19,6 +19,10 @@ web/sites/*/services*.yml
 !web/sites/*/services.pantheon.*.yml
 !web/sites/*/services.yml
 
+# BLT looks for local.settings.php rather than settings.local.php.
+web/sites/settings/local.settings.php
+web/sites/*/settings/local.settings.php
+
 # Ignore paths that contain user-generated content.
 /web/sites/*/files
 /web/sites/*/private


### PR DESCRIPTION
When using BLT, blt.settings.php looks for local settings thus:

```
// Local global and site-specific settings.
if (EnvironmentDetector::isLocalEnv()) {
  $settings_files[] = DRUPAL_ROOT . '/sites/settings/local.settings.php';
  $settings_files[] = DRUPAL_ROOT . "/sites/$site_name/settings/local.settings.php";
}
```

This PR adds those locations to the example .gitignore