### PR TITLE
Adding a dedicated gulp build:dist task that purges Tailwind CSS on demand

### DIFF
--- a/themes/wilson_theme_starterkit/README.md
+++ b/themes/wilson_theme_starterkit/README.md
@@ -12,18 +12,16 @@ theme uses the Tailwind 2.0 CSS framework.
 
 ## Usage of this theme
 
-The `node_modules`, `css` and `js` folders are Git ignored in this theme and must be built using `blt`, or by the `npm` & `gulp` commands as below.
+The `node_modules`, `css` and `js` folders are Git ignored in this theme and must be built using `npm` & `gulp` commands as below.
 
-The quickest way to get started with the theme it to run
+Run the following steps:
 
-`ddev exec blt source:build:frontend`
+- Run `npm install` in the wilson_theme_starterkit directory.
+- Run `gulp build` in the wilson_theme_starterkit directory to get the up-to-date CSS file.
 
-from the host machine.
+To ensure that these are run with a managed version of Node, it's best to run these inside the project virtual machine.
 
-This will load the node dependencies and run gulp to build the theme. If you want to run these steps independently,
-you can use `ddev exec blt source:build:frontend-reqs` or `ddev exec blt source:build:frontend-assets` commands respectively.
-
-There are more gulp tasks available by running the following whilst inside the theme folder on the ddev instance:
+There are more gulp tasks available by running the following whilst inside the theme folder:
 - `gulp lint`
 - `gulp lint:css`
 - `gulp build`
@@ -31,6 +29,8 @@ There are more gulp tasks available by running the following whilst inside the t
 - `gulp build:styles`
 - `gulp build:scripts`
 - `gulp watch`
+
+When building the theme for production (via CI for instance) use the `gulp build:dist` command to ensure the Tailwind CSS is purged of un-used classes. See below for more information.
 
 ## Tailwind purging (on `gulp build:dist` only)
 

--- a/themes/wilson_theme_starterkit/README.md
+++ b/themes/wilson_theme_starterkit/README.md
@@ -3,27 +3,39 @@
 A theme for the Wilson installation profile, based on the Stable core theme. This is a starterkit and should be renamed for project use. This
 theme uses the Tailwind 2.0 CSS framework.
 
-# Tailwind help
+## Tailwind help
 
 - [What is Tailwind?](https://tailwindcss.com/)
 - [Configure tailwind.config.js](https://tailwindcss.com/docs/configuration)
 - [Tailwind cheat sheet](https://nerdcave.com/tailwind-cheat-sheet)
 - [TailwindUI inspiration](https://tailwindui.com/components)
 
-# Usage of this theme
+## Usage of this theme
 
-The `node_modules`, `css` and `js` folders are Git ignored in this theme and must be built using the `npm` & `gulp` commands as below.
+The `node_modules`, `css` and `js` folders are Git ignored in this theme and must be built using `blt`, or by the `npm` & `gulp` commands as below.
 
-Run the following steps on the host machine:
+The quickest way to get started with the theme it to run
 
-- Run `npm install` in the wilson_theme_starterkit directory.
-- Run `gulp build` in the wilson_theme_starterkit directory to get the up-to-date CSS file.
+`ddev exec blt source:build:frontend`
 
-# Available Gulp tasks
+from the host machine.
 
+This will load the node dependencies and run gulp to build the theme. If you want to run these steps independently,
+you can use `ddev exec blt source:build:frontend-reqs` or `ddev exec blt source:build:frontend-assets` commands respectively.
+
+There are more gulp tasks available by running the following whilst inside the theme folder on the ddev instance:
 - `gulp lint`
 - `gulp lint:css`
 - `gulp build`
+- `gulp build:dist`
 - `gulp build:styles`
 - `gulp build:scripts`
 - `gulp watch`
+
+## Tailwind purging (on `gulp build:dist` only)
+
+To dramatically reduce the size of the compiled theme CSS, Tailwind Purge is enabled on this theme when built via `gulp build:dist`. Use `gulp build` locally to compile CSS with all Tailwind classes.
+
+Only Tailwind classes that are used in the template files or SASS will be included in the purged CSS. To use Tailwind classes in config (e.g. in Webform fields), you must add the class to the `purge:options:safelist` in `tailwind.config.js`.
+
+You can also tell Tailwind to scan more paths when assessing what to purge (e.g. a directory containing a React app). Add the relative path of the `purge:content` section in `tailwind.config.js`.

--- a/themes/wilson_theme_starterkit/tailwind.config.js
+++ b/themes/wilson_theme_starterkit/tailwind.config.js
@@ -3,7 +3,6 @@ const colors = require('tailwindcss/colors')
 
 module.exports = {
   purge: {
-    enabled: true,
     content: [
       './templates/**/*.html.twig',
       './scripts/**/*.js',


### PR DESCRIPTION
Originally I had Tailwind purge enabled all the time but this can sometimes get in the way when doing rapid development locally. So this PR introduces distinct build tasks for local development (no purging) and production/CI (with purging). This works by toggling on and off a NODE_ENV flag that is used by Tailwind.

Going forward, use `gulp build` if you want a complete Tailwind CSS file and `gulp build:dist` for a much much smaller purged CSS file. 

Remember to add specific paths to the following section of tailwind.config.js if you want them to be included in the purging process (e.g. the source files of a react app or a custom module that introduces additional templates).

```
purge: {
    content: [
      './templates/**/*.html.twig',
      './scripts/**/*.js',
      './*.theme',
    ]
    ...
```