### PR TITLE
Theme accessibility enhancements

### DIFF
--- a/themes/wilson_theme_starterkit/scripts/components/adaptivePanels.js
+++ b/themes/wilson_theme_starterkit/scripts/components/adaptivePanels.js
@@ -21,10 +21,11 @@
         let activeIndex = null;
         const accordion = el;
         const headings = accordion.querySelectorAll('.panels__title');
+        const buttons = accordion.querySelectorAll('.panels__button');
         const panels = accordion.querySelectorAll('.panels__panel');
         const tabs = [];
 
-        // Setup a container that may be used to display tabs.
+        // Set up a container that may be used to display tabs.
         const tabsContainer = document.createElement('ul');
         tabsContainer.classList.add('panels__tabs');
         tabsContainer.setAttribute('aria-hidden', 'true');
@@ -35,7 +36,7 @@
           tabs[index].classList.add('is-active');
           panels[index].classList.add('is-active');
           activeIndex = index;
-          panels[index].setAttribute('aria-expanded', 'true');
+          buttons[index].setAttribute('aria-expanded', 'true');
         };
 
         const hidePanel = (index) => {
@@ -43,14 +44,14 @@
             headings[index].classList.remove('is-active');
             tabs[index].classList.remove('is-active');
             panels[index].classList.remove('is-active');
-            panels[index].setAttribute('aria-expanded', 'false');
+            buttons[index].setAttribute('aria-expanded', 'false');
           }
         };
 
         // Cycle through the headings to create tabs and handle click events.
         Array.prototype.forEach.call(headings, (heading, i) => {
           // Create a tab item.
-          const tabText = document.createTextNode(heading.querySelector('button').innerText);
+          const tabText = document.createTextNode(buttons[i].innerText);
           const tabLink = document.createElement('button');
           const tabItem = document.createElement('li');
           tabLink.setAttribute('role', 'tab');

--- a/themes/wilson_theme_starterkit/scripts/components/mainMenu.js
+++ b/themes/wilson_theme_starterkit/scripts/components/mainMenu.js
@@ -22,24 +22,27 @@
         const submenuLinks = context.querySelectorAll('.navigation li.has-submenu > a, .navigation li.has-submenu > span');
         const backLinks = context.querySelectorAll('.back-link a');
 
-        // Remove active state from link.
+        // Remove active state from active menu links.
         const removeActiveLink = (activeLinks) => {
           Array.prototype.forEach.call(activeLinks, (activeLink) => {
             activeLink.classList.remove('menu-item-active');
+            if (activeLink.hasAttribute('aria-expanded') && activeLink.getAttribute('aria-expanded') === 'true') {
+              activeLink.setAttribute('aria-expanded', 'false');
+            }
           });
         };
 
         // Setup event listeners for back links.
         Array.prototype.forEach.call(backLinks, (backLink) => {
           const parentWrapper = backLink.closest('.submenu-wrapper');
-          const parentMenu = backLink.parentElement;
+          const parentMenuLink = parentWrapper.previousElementSibling;
 
           backLink.addEventListener('click', (event) => {
             event.preventDefault();
             event.stopPropagation();
 
             parentWrapper.classList.remove('menu-item-active');
-            parentMenu.setAttribute('aria-expanded', 'false');
+            parentMenuLink.setAttribute('aria-expanded', 'false');
           });
         });
 
@@ -54,16 +57,21 @@
           link.addEventListener('click', (event) => {
             event.preventDefault();
 
-            // Remove active state from previously selected links.
+            const activeMenuItems = parentEl.querySelectorAll('.menu-item-active');
             if (!link.classList.contains('menu-item-active')) {
-              removeActiveLink(parentEl.querySelectorAll('.menu-item-active'));
+              // Remove active state from previously selected links.
+              if (activeMenuItems) {
+                removeActiveLink(activeMenuItems);
+              }
+              // Set the clicked link's submenu to active.
+              link.classList.add('menu-item-active');
+              link.setAttribute('aria-expanded', 'true');
+              siblingEl.classList.add('menu-item-active');
+            } else {
+              link.classList.remove('menu-item-active');
+              link.setAttribute('aria-expanded', 'false');
+              siblingEl.classList.remove('menu-item-active');
             }
-
-            // Set the clicked link's submenu to active.
-            link.classList.toggle('menu-item-active');
-            siblingEl.classList.toggle('menu-item-active');
-            siblingEl.setAttribute('aria-expanded', 'true');
-            parentEl.setAttribute('aria-expanded', 'false');
           });
         });
 
@@ -92,6 +100,7 @@
         // Setup mobile header.
         const menuHeader = document.createElement('div');
         const menuClose = document.createElement('button');
+        const menuOpen = document.querySelector('.menu-open');
 
         menuHeader.classList.add('mobile-header');
         menuClose.classList.add('menu-close', 'btn', 'btn--secondary');
@@ -100,32 +109,32 @@
         nav.prepend(menuHeader);
 
         menuClose.addEventListener('click', () => {
+          const activeMenuItems = document.querySelectorAll('.menu-item-active');
           body.classList.remove('mobile-menu-is-active');
           nav.classList.remove('menu-item-active');
           topLevelMenu.classList.remove('menu-item-active');
-          topLevelMenu.setAttribute('aria-expanded', 'false');
+          menuOpen.setAttribute('aria-expanded', 'false');
+
+          if (activeMenuItems) {
+            removeActiveLink(activeMenuItems);
+          }
         });
 
         // Create event listener for menu toggle icon.
-        const menuOpen = document.querySelector('.menu-open');
-
         if (menuOpen) {
           menuOpen.addEventListener('click', () => {
-            const activeMenus = document.querySelectorAll('.menu-item-active');
+            const activeMenuItems = document.querySelectorAll('.menu-item-active');
             const firstLink = topLevelMenu.querySelector('.menu-level-0 > li > a');
 
             body.classList.add('mobile-menu-is-active');
             nav.classList.add('menu-item-active');
             topLevelMenu.classList.add('menu-item-active');
-            topLevelMenu.setAttribute('aria-expanded', 'true');
+            menuOpen.setAttribute('aria-expanded', 'true');
             firstLink.focus();
 
             // Remove active class on any submenus when the menu is toggled.
-            if (activeMenus.length > 0) {
-              activeMenus.forEach((activeMenu) => {
-                activeMenu.classList.remove('menu-item-active');
-                activeMenu.setAttribute('aria-expanded', 'false');
-              });
+            if (activeMenuItems) {
+              removeActiveLink(activeMenuItems);
             }
           });
         }
@@ -133,10 +142,10 @@
         // Clear any active menus when clicking outside of the navigation.
         document.addEventListener('mouseup', (e) => {
           if (!nav.contains(e.target)) {
-            const activeItems = context.querySelectorAll('.menu-item-active');
-            Array.prototype.forEach.call(activeItems, (activeItem) => {
-              activeItem.classList.remove('menu-item-active');
-            });
+            const activeMenuItems = context.querySelectorAll('.menu-item-active');
+            if (activeMenuItems) {
+              removeActiveLink(activeMenuItems);
+            }
           }
         });
       }

--- a/themes/wilson_theme_starterkit/templates/block/block--local-tasks-block.html.twig
+++ b/themes/wilson_theme_starterkit/templates/block/block--local-tasks-block.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Theme override to display a block.
+ * Theme override to display a local tasks block.
  *
  * Available variables:
  * - plugin_id: The ID of the block implementation.

--- a/themes/wilson_theme_starterkit/templates/block/block--system-branding-block.html.twig
+++ b/themes/wilson_theme_starterkit/templates/block/block--system-branding-block.html.twig
@@ -1,3 +1,36 @@
+{#
+/**
+ * @file
+ * Theme override for a system branding block.
+ *
+ * Available variables:
+ * - plugin_id: The ID of the block implementation.
+ * - label: The configured label of the block if visible.
+ * - configuration: A list of the block's configuration values.
+ *   - label: The configured label for the block.
+ *   - label_display: The display settings for the label.
+ *   - provider: The module or other provider that provided this block plugin.
+ *   - Block plugin specific settings will also be stored here.
+ * - content: The content of this block.
+ * - attributes: HTML attributes for the containing element.
+ *   - id: A valid HTML ID and guaranteed unique.
+ * - title_attributes: HTML attributes for the title element.
+ * - content_attributes: HTML attributes for the content element.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ *
+ * Headings should be used on navigation menus that consistently appear on
+ * multiple pages. When this menu block's label is configured to not be
+ * displayed, it is automatically made invisible using the 'visually-hidden' CSS
+ * class, which still keeps it visible for screen-readers and assistive
+ * technology. Headings allow screen-reader and keyboard only users to navigate
+ * to or skip the links.
+ * See http://juicystudio.com/article/screen-readers-display-none.php and
+ * http://www.w3.org/TR/WCAG-TECHS/H42.html for more information.
+ */
+#}
 {% block content %}
   {% if site_logo %}
     <a href="{{ path('<front>') }}" aria-label="{{ 'Home'|t }}" rel="home" class="inline-block w-28 lg:w-36 border-2 text-current hover:text-current">

--- a/themes/wilson_theme_starterkit/templates/content/media--image--default.html.twig
+++ b/themes/wilson_theme_starterkit/templates/content/media--image--default.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Theme override to display a media item.
+ * Theme override to display a default media item.
  *
  * Available variables:
  * - name: Name of the media.

--- a/themes/wilson_theme_starterkit/templates/content/media--image--thumbnail.html.twig
+++ b/themes/wilson_theme_starterkit/templates/content/media--image--thumbnail.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Theme override to display a media item.
+ * Theme override to display a thumbail media item.
  *
  * Available variables:
  * - name: Name of the media.

--- a/themes/wilson_theme_starterkit/templates/content/media--remote-video--default.html.twig
+++ b/themes/wilson_theme_starterkit/templates/content/media--remote-video--default.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Theme override to display a media item.
+ * Theme override to display a default remote video media item.
  *
  * Available variables:
  * - name: Name of the media.

--- a/themes/wilson_theme_starterkit/templates/content/media--remote-video.html.twig
+++ b/themes/wilson_theme_starterkit/templates/content/media--remote-video.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Theme override to display a media item.
+ * Theme override to display a remote video media item.
  *
  * Available variables:
  * - name: Name of the media.

--- a/themes/wilson_theme_starterkit/templates/content/media--video--default.html.twig
+++ b/themes/wilson_theme_starterkit/templates/content/media--video--default.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Theme override to display a media item.
+ * Theme override to display a default video media item.
  *
  * Available variables:
  * - name: Name of the media.

--- a/themes/wilson_theme_starterkit/templates/content/media--video.html.twig
+++ b/themes/wilson_theme_starterkit/templates/content/media--video.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Theme override to display a media item.
+ * Theme override to display a video media item.
  *
  * Available variables:
  * - name: Name of the media.

--- a/themes/wilson_theme_starterkit/templates/content/node--article--full.html.twig
+++ b/themes/wilson_theme_starterkit/templates/content/node--article--full.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Theme override to display a node.
+ * Theme override to display an article node.
  *
  * Available variables:
  * - node: The node entity with limited access to object properties and methods.

--- a/themes/wilson_theme_starterkit/templates/content/node--article--teaser.html.twig
+++ b/themes/wilson_theme_starterkit/templates/content/node--article--teaser.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Theme override to display a node.
+ * Theme override to display an article teaser node.
  *
  * Available variables:
  * - node: The node entity with limited access to object properties and methods.

--- a/themes/wilson_theme_starterkit/templates/content/node--landing-page--full.html.twig
+++ b/themes/wilson_theme_starterkit/templates/content/node--landing-page--full.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Theme override to display a node.
+ * Theme override to display a landing page node.
  *
  * Available variables:
  * - node: The node entity with limited access to object properties and methods.

--- a/themes/wilson_theme_starterkit/templates/content/node--teaser.html.twig
+++ b/themes/wilson_theme_starterkit/templates/content/node--teaser.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Theme override to display a node.
+ * Theme override to display a teaser node.
  *
  * Available variables:
  * - node: The node entity with limited access to object properties and methods.

--- a/themes/wilson_theme_starterkit/templates/field/field--field-media-image.html.twig
+++ b/themes/wilson_theme_starterkit/templates/field/field--field-media-image.html.twig
@@ -1,3 +1,41 @@
+{#
+/**
+ * @file
+ * Theme override for a media image field.
+ *
+ * To override output, copy the "field.html.twig" from the templates directory
+ * to your theme's directory and customize it, just like customizing other
+ * Drupal templates such as page.html.twig or node.html.twig.
+ *
+ * Instead of overriding the theming for all fields, you can also just override
+ * theming for a subset of fields using
+ * @link themeable Theme hook suggestions. @endlink For example,
+ * here are some theme hook suggestions that can be used for a field_foo field
+ * on an article node type:
+ * - field--node--field-foo--article.html.twig
+ * - field--node--field-foo.html.twig
+ * - field--node--article.html.twig
+ * - field--field-foo.html.twig
+ * - field--text-with-summary.html.twig
+ * - field.html.twig
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - label_hidden: Whether to show the field label or not.
+ * - title_attributes: HTML attributes for the title.
+ * - label: The label for the field.
+ * - multiple: TRUE if a field can contain multiple items.
+ * - items: List of all the field items. Each item contains:
+ *   - attributes: List of HTML attributes for each item.
+ *   - content: The field item's content.
+ * - entity_type: The entity type to which the field belongs.
+ * - field_name: The name of the field.
+ * - field_type: The type of the field.
+ * - label_display: The display settings for the label.
+ *
+ * @see template_preprocess_field()
+ */
+#}
 {% for item in items %}
   {{ item.content }}
 {% endfor %}

--- a/themes/wilson_theme_starterkit/templates/field/field--field-media-oembed-video.html.twig
+++ b/themes/wilson_theme_starterkit/templates/field/field--field-media-oembed-video.html.twig
@@ -1,3 +1,41 @@
+{#
+/**
+ * @file
+ * Theme override for a media oembed field.
+ *
+ * To override output, copy the "field.html.twig" from the templates directory
+ * to your theme's directory and customize it, just like customizing other
+ * Drupal templates such as page.html.twig or node.html.twig.
+ *
+ * Instead of overriding the theming for all fields, you can also just override
+ * theming for a subset of fields using
+ * @link themeable Theme hook suggestions. @endlink For example,
+ * here are some theme hook suggestions that can be used for a field_foo field
+ * on an article node type:
+ * - field--node--field-foo--article.html.twig
+ * - field--node--field-foo.html.twig
+ * - field--node--article.html.twig
+ * - field--field-foo.html.twig
+ * - field--text-with-summary.html.twig
+ * - field.html.twig
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - label_hidden: Whether to show the field label or not.
+ * - title_attributes: HTML attributes for the title.
+ * - label: The label for the field.
+ * - multiple: TRUE if a field can contain multiple items.
+ * - items: List of all the field items. Each item contains:
+ *   - attributes: List of HTML attributes for each item.
+ *   - content: The field item's content.
+ * - entity_type: The entity type to which the field belongs.
+ * - field_name: The name of the field.
+ * - field_type: The type of the field.
+ * - label_display: The display settings for the label.
+ *
+ * @see template_preprocess_field()
+ */
+#}
 {% for item in items %}
   {{ item.content }}
 {% endfor %}

--- a/themes/wilson_theme_starterkit/templates/field/field--field-media-video-file.html.twig
+++ b/themes/wilson_theme_starterkit/templates/field/field--field-media-video-file.html.twig
@@ -1,3 +1,41 @@
+{#
+/**
+ * @file
+ * Theme override for a video file field.
+ *
+ * To override output, copy the "field.html.twig" from the templates directory
+ * to your theme's directory and customize it, just like customizing other
+ * Drupal templates such as page.html.twig or node.html.twig.
+ *
+ * Instead of overriding the theming for all fields, you can also just override
+ * theming for a subset of fields using
+ * @link themeable Theme hook suggestions. @endlink For example,
+ * here are some theme hook suggestions that can be used for a field_foo field
+ * on an article node type:
+ * - field--node--field-foo--article.html.twig
+ * - field--node--field-foo.html.twig
+ * - field--node--article.html.twig
+ * - field--field-foo.html.twig
+ * - field--text-with-summary.html.twig
+ * - field.html.twig
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - label_hidden: Whether to show the field label or not.
+ * - title_attributes: HTML attributes for the title.
+ * - label: The label for the field.
+ * - multiple: TRUE if a field can contain multiple items.
+ * - items: List of all the field items. Each item contains:
+ *   - attributes: List of HTML attributes for each item.
+ *   - content: The field item's content.
+ * - entity_type: The entity type to which the field belongs.
+ * - field_name: The name of the field.
+ * - field_type: The type of the field.
+ * - label_display: The display settings for the label.
+ *
+ * @see template_preprocess_field()
+ */
+#}
 {% for item in items %}
   {{ item.content }}
 {% endfor %}

--- a/themes/wilson_theme_starterkit/templates/field/field--field-pre-header.html.twig
+++ b/themes/wilson_theme_starterkit/templates/field/field--field-pre-header.html.twig
@@ -1,3 +1,41 @@
+{#
+/**
+ * @file
+ * Theme override for a preheader field.
+ *
+ * To override output, copy the "field.html.twig" from the templates directory
+ * to your theme's directory and customize it, just like customizing other
+ * Drupal templates such as page.html.twig or node.html.twig.
+ *
+ * Instead of overriding the theming for all fields, you can also just override
+ * theming for a subset of fields using
+ * @link themeable Theme hook suggestions. @endlink For example,
+ * here are some theme hook suggestions that can be used for a field_foo field
+ * on an article node type:
+ * - field--node--field-foo--article.html.twig
+ * - field--node--field-foo.html.twig
+ * - field--node--article.html.twig
+ * - field--field-foo.html.twig
+ * - field--text-with-summary.html.twig
+ * - field.html.twig
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - label_hidden: Whether to show the field label or not.
+ * - title_attributes: HTML attributes for the title.
+ * - label: The label for the field.
+ * - multiple: TRUE if a field can contain multiple items.
+ * - items: List of all the field items. Each item contains:
+ *   - attributes: List of HTML attributes for each item.
+ *   - content: The field item's content.
+ * - entity_type: The entity type to which the field belongs.
+ * - field_name: The name of the field.
+ * - field_type: The type of the field.
+ * - label_display: The display settings for the label.
+ *
+ * @see template_preprocess_field()
+ */
+#}
 {% set classes = [
   'inline-block',
   'uppercase',

--- a/themes/wilson_theme_starterkit/templates/field/field--field-primary-cta.html.twig
+++ b/themes/wilson_theme_starterkit/templates/field/field--field-primary-cta.html.twig
@@ -1,3 +1,41 @@
+{#
+/**
+ * @file
+ * Theme override for a primary CTA field.
+ *
+ * To override output, copy the "field.html.twig" from the templates directory
+ * to your theme's directory and customize it, just like customizing other
+ * Drupal templates such as page.html.twig or node.html.twig.
+ *
+ * Instead of overriding the theming for all fields, you can also just override
+ * theming for a subset of fields using
+ * @link themeable Theme hook suggestions. @endlink For example,
+ * here are some theme hook suggestions that can be used for a field_foo field
+ * on an article node type:
+ * - field--node--field-foo--article.html.twig
+ * - field--node--field-foo.html.twig
+ * - field--node--article.html.twig
+ * - field--field-foo.html.twig
+ * - field--text-with-summary.html.twig
+ * - field.html.twig
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - label_hidden: Whether to show the field label or not.
+ * - title_attributes: HTML attributes for the title.
+ * - label: The label for the field.
+ * - multiple: TRUE if a field can contain multiple items.
+ * - items: List of all the field items. Each item contains:
+ *   - attributes: List of HTML attributes for each item.
+ *   - content: The field item's content.
+ * - entity_type: The entity type to which the field belongs.
+ * - field_name: The name of the field.
+ * - field_type: The type of the field.
+ * - label_display: The display settings for the label.
+ *
+ * @see template_preprocess_field()
+ */
+#}
 {% set classes = [
   'btn',
   'btn--primary',

--- a/themes/wilson_theme_starterkit/templates/field/field--field-secondary-cta.html.twig
+++ b/themes/wilson_theme_starterkit/templates/field/field--field-secondary-cta.html.twig
@@ -1,3 +1,41 @@
+{#
+/**
+ * @file
+ * Theme override for a secondary CTA field.
+ *
+ * To override output, copy the "field.html.twig" from the templates directory
+ * to your theme's directory and customize it, just like customizing other
+ * Drupal templates such as page.html.twig or node.html.twig.
+ *
+ * Instead of overriding the theming for all fields, you can also just override
+ * theming for a subset of fields using
+ * @link themeable Theme hook suggestions. @endlink For example,
+ * here are some theme hook suggestions that can be used for a field_foo field
+ * on an article node type:
+ * - field--node--field-foo--article.html.twig
+ * - field--node--field-foo.html.twig
+ * - field--node--article.html.twig
+ * - field--field-foo.html.twig
+ * - field--text-with-summary.html.twig
+ * - field.html.twig
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - label_hidden: Whether to show the field label or not.
+ * - title_attributes: HTML attributes for the title.
+ * - label: The label for the field.
+ * - multiple: TRUE if a field can contain multiple items.
+ * - items: List of all the field items. Each item contains:
+ *   - attributes: List of HTML attributes for each item.
+ *   - content: The field item's content.
+ * - entity_type: The entity type to which the field belongs.
+ * - field_name: The name of the field.
+ * - field_type: The type of the field.
+ * - label_display: The display settings for the label.
+ *
+ * @see template_preprocess_field()
+ */
+#}
 {% set classes = [
   'btn',
   'btn--secondary',

--- a/themes/wilson_theme_starterkit/templates/field/field--field-sections.html.twig
+++ b/themes/wilson_theme_starterkit/templates/field/field--field-sections.html.twig
@@ -1,3 +1,41 @@
+{#
+/**
+ * @file
+ * Theme override for a sections field.
+ *
+ * To override output, copy the "field.html.twig" from the templates directory
+ * to your theme's directory and customize it, just like customizing other
+ * Drupal templates such as page.html.twig or node.html.twig.
+ *
+ * Instead of overriding the theming for all fields, you can also just override
+ * theming for a subset of fields using
+ * @link themeable Theme hook suggestions. @endlink For example,
+ * here are some theme hook suggestions that can be used for a field_foo field
+ * on an article node type:
+ * - field--node--field-foo--article.html.twig
+ * - field--node--field-foo.html.twig
+ * - field--node--article.html.twig
+ * - field--field-foo.html.twig
+ * - field--text-with-summary.html.twig
+ * - field.html.twig
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - label_hidden: Whether to show the field label or not.
+ * - title_attributes: HTML attributes for the title.
+ * - label: The label for the field.
+ * - multiple: TRUE if a field can contain multiple items.
+ * - items: List of all the field items. Each item contains:
+ *   - attributes: List of HTML attributes for each item.
+ *   - content: The field item's content.
+ * - entity_type: The entity type to which the field belongs.
+ * - field_name: The name of the field.
+ * - field_type: The type of the field.
+ * - label_display: The display settings for the label.
+ *
+ * @see template_preprocess_field()
+ */
+#}
 {% for item in items %}
   {{ item.content }}
 {% endfor %}

--- a/themes/wilson_theme_starterkit/templates/layout/page.html.twig
+++ b/themes/wilson_theme_starterkit/templates/layout/page.html.twig
@@ -1,4 +1,49 @@
-<header aria-label="{{ 'Header'|t }}" class="header sticky top-0 lg:relative lg:top-auto z-20">
+{#
+/**
+ * @file
+ * Theme override to display a single page.
+ *
+ * The doctype, html, head and body tags are not in this template. Instead they
+ * can be found in the html.html.twig template in this directory.
+ *
+ * Available variables:
+ *
+ * General utility variables:
+ * - base_path: The base URL path of the Drupal installation. Will usually be
+ *   "/" unless you have installed Drupal in a sub-directory.
+ * - is_front: A flag indicating if the current page is the front page.
+ * - logged_in: A flag indicating if the user is registered and signed in.
+ * - is_admin: A flag indicating if the user has permission to access
+ *   administration pages.
+ *
+ * Site identity:
+ * - front_page: The URL of the front page. Use this instead of base_path when
+ *   linking to the front page. This includes the language domain or prefix.
+ *
+ * Page content (in order of occurrence in the default page.html.twig):
+ * - messages: Status and error messages. Should be displayed prominently.
+ * - node: Fully loaded node, if there is an automatically-loaded node
+ *   associated with the page and the node ID is the second argument in the
+ *   page's path (e.g. node/12345 and node/12345/revisions, but not
+ *   comment/reply/12345).
+ *
+ * Regions:
+ * - page.header: Items for the header region.
+ * - page.primary_menu: Items for the primary menu region.
+ * - page.secondary_menu: Items for the secondary menu region.
+ * - page.highlighted: Items for the highlighted content region.
+ * - page.help: Dynamic help text, mostly for admin pages.
+ * - page.content: The main content of the current page.
+ * - page.sidebar_first: Items for the first sidebar.
+ * - page.sidebar_second: Items for the second sidebar.
+ * - page.footer: Items for the footer region.
+ * - page.breadcrumb: Items for the breadcrumb region.
+ *
+ * @see template_preprocess_page()
+ * @see html.html.twig
+ */
+#}
+<header class="header sticky top-0 lg:relative lg:top-auto z-20">
   {% if page.header_links %}
     <div class="bg-primary py-3 lg:py-4">
       {{ page.header_links }}
@@ -30,8 +75,8 @@
   </div>
 {% endif %}
 
-<main role="main">
-  <a name="main-content" tabindex="-1"></a>
+<main>
+  <a tabindex="-1"></a>
 
   <div class="main-content">
     {{ page.content }}
@@ -46,7 +91,7 @@
 {% endif %}
 
 {% if page.footer_col_one or page.footer_col_two or page.footer_col_three or page.footer_col_four %}
-  <footer class="bg-grey-200" role="contentinfo">
+  <footer class="bg-grey-200">
     <div class="container mx-auto px-5 py-16 md:flex md:flex-no-wrap">
 
       {% if page.footer_col_one %}

--- a/themes/wilson_theme_starterkit/templates/layout/region--breadcrumb.html.twig
+++ b/themes/wilson_theme_starterkit/templates/layout/region--breadcrumb.html.twig
@@ -1,3 +1,17 @@
+{#
+/**
+ * @file
+ * Theme override to display a breadcrumb region.
+ *
+ * Available variables:
+ * - content: The content for this region, typically blocks.
+ * - attributes: HTML attributes for the region <div>.
+ * - region: The name of the region variable as defined in the theme's
+ *   .info.yml file.
+ *
+ * @see template_preprocess_region()
+ */
+#}
 {% if content %}
   <div class="pt-5">
     <div class="container mx-auto px-5">

--- a/themes/wilson_theme_starterkit/templates/layout/region--footer-col-four.html.twig
+++ b/themes/wilson_theme_starterkit/templates/layout/region--footer-col-four.html.twig
@@ -1,3 +1,17 @@
+{#
+/**
+ * @file
+ * Theme override to display a footer four column region.
+ *
+ * Available variables:
+ * - content: The content for this region, typically blocks.
+ * - attributes: HTML attributes for the region <div>.
+ * - region: The name of the region variable as defined in the theme's
+ *   .info.yml file.
+ *
+ * @see template_preprocess_region()
+ */
+#}
 {% if content %}
   <div class="md:w-3/12 py-4 md:py-0 md:px-8">
     {{ content }}

--- a/themes/wilson_theme_starterkit/templates/layout/region--footer-col-one.html.twig
+++ b/themes/wilson_theme_starterkit/templates/layout/region--footer-col-one.html.twig
@@ -1,3 +1,17 @@
+{#
+/**
+ * @file
+ * Theme override to display a footer one column region.
+ *
+ * Available variables:
+ * - content: The content for this region, typically blocks.
+ * - attributes: HTML attributes for the region <div>.
+ * - region: The name of the region variable as defined in the theme's
+ *   .info.yml file.
+ *
+ * @see template_preprocess_region()
+ */
+#}
 {% if content %}
   <div class="md:w-3/12 py-4 md:py-0 md:px-8">
     {{ content }}

--- a/themes/wilson_theme_starterkit/templates/layout/region--footer-col-three.html.twig
+++ b/themes/wilson_theme_starterkit/templates/layout/region--footer-col-three.html.twig
@@ -1,3 +1,17 @@
+{#
+/**
+ * @file
+ * Theme override to display a footer one column region.
+ *
+ * Available variables:
+ * - content: The content for this region, typically blocks.
+ * - attributes: HTML attributes for the region <div>.
+ * - region: The name of the region variable as defined in the theme's
+ *   .info.yml file.
+ *
+ * @see template_preprocess_region()
+ */
+#}
 {% if content %}
   <div class="md:w-3/12 py-4 md:py-0 md:px-8">
     {{ content }}

--- a/themes/wilson_theme_starterkit/templates/layout/region--footer-col-two.html.twig
+++ b/themes/wilson_theme_starterkit/templates/layout/region--footer-col-two.html.twig
@@ -1,3 +1,17 @@
+{#
+/**
+ * @file
+ * Theme override to display a footer one column region.
+ *
+ * Available variables:
+ * - content: The content for this region, typically blocks.
+ * - attributes: HTML attributes for the region <div>.
+ * - region: The name of the region variable as defined in the theme's
+ *   .info.yml file.
+ *
+ * @see template_preprocess_region()
+ */
+#}
 {% if content %}
   <div class="md:w-3/12 py-4 md:py-0 md:px-8">
     {{ content }}

--- a/themes/wilson_theme_starterkit/templates/layout/region--header-links.html.twig
+++ b/themes/wilson_theme_starterkit/templates/layout/region--header-links.html.twig
@@ -1,3 +1,17 @@
+{#
+/**
+ * @file
+ * Theme override to display a header links region.
+ *
+ * Available variables:
+ * - content: The content for this region, typically blocks.
+ * - attributes: HTML attributes for the region <div>.
+ * - region: The name of the region variable as defined in the theme's
+ *   .info.yml file.
+ *
+ * @see template_preprocess_region()
+ */
+#}
 {% if content %}
   <div class="container mx-auto px-5 flex justify-between items-center">
     {{ content }}

--- a/themes/wilson_theme_starterkit/templates/layout/region--header-navigation.html.twig
+++ b/themes/wilson_theme_starterkit/templates/layout/region--header-navigation.html.twig
@@ -1,3 +1,17 @@
+{#
+/**
+ * @file
+ * Theme override to display a header navigation region.
+ *
+ * Available variables:
+ * - content: The content for this region, typically blocks.
+ * - attributes: HTML attributes for the region <div>.
+ * - region: The name of the region variable as defined in the theme's
+ *   .info.yml file.
+ *
+ * @see template_preprocess_region()
+ */
+#}
 {% if content %}
   {{ content }}
 {% endif %}

--- a/themes/wilson_theme_starterkit/templates/layout/region--off-canvas.html.twig
+++ b/themes/wilson_theme_starterkit/templates/layout/region--off-canvas.html.twig
@@ -1,5 +1,17 @@
+{#
+/**
+ * @file
+ * Theme override to display a off canvas region.
+ *
+ * Available variables:
+ * - content: The content for this region, typically blocks.
+ * - attributes: HTML attributes for the region <div>.
+ * - region: The name of the region variable as defined in the theme's
+ *   .info.yml file.
+ *
+ * @see template_preprocess_region()
+ */
+#}
 {% if content %}
-
   {{ content }}
-
 {% endif %}

--- a/themes/wilson_theme_starterkit/templates/navigation/menu--main.html.twig
+++ b/themes/wilson_theme_starterkit/templates/navigation/menu--main.html.twig
@@ -21,8 +21,8 @@
 {% import _self as menus %}
 
 {#
-We call a macro which calls itself to render the full tree.
-@see https://twig.symfony.com/doc/1.x/tags/macro.html
+  We call a macro which calls itself to render the full tree.
+  @see https://twig.symfony.com/doc/1.x/tags/macro.html
 #}
 {{ menus.menu_links(items, attributes, 0, 'Main Menu'|t, '') }}
 

--- a/themes/wilson_theme_starterkit/templates/navigation/menu--main.html.twig
+++ b/themes/wilson_theme_starterkit/templates/navigation/menu--main.html.twig
@@ -1,3 +1,23 @@
+{#
+/**
+ * @file
+ * Theme override to display a main menu.
+ *
+ * Available variables:
+ * - menu_name: The machine name of the menu.
+ * - items: A nested list of menu items. Each menu item contains:
+ *   - attributes: HTML attributes for the menu item.
+ *   - below: The menu item child items.
+ *   - title: The menu link title.
+ *   - url: The menu link url, instance of \Drupal\Core\Url
+ *   - localized_options: Menu link localized options.
+ *   - is_expanded: TRUE if the link has visible children within the current
+ *     menu tree.
+ *   - is_collapsed: TRUE if the link has children within the current menu tree
+ *     that are not currently visible.
+ *   - in_active_trail: TRUE if the link is in the active trail.
+ */
+#}
 {% import _self as menus %}
 
 {#

--- a/themes/wilson_theme_starterkit/templates/navigation/menu--main.html.twig
+++ b/themes/wilson_theme_starterkit/templates/navigation/menu--main.html.twig
@@ -21,8 +21,8 @@
 {% import _self as menus %}
 
 {#
-  We call a macro which calls itself to render the full tree.
-  @see https://twig.symfony.com/doc/1.x/tags/macro.html
+We call a macro which calls itself to render the full tree.
+@see https://twig.symfony.com/doc/1.x/tags/macro.html
 #}
 {{ menus.menu_links(items, attributes, 0, 'Main Menu'|t, '') }}
 
@@ -38,45 +38,44 @@
 
     {% set classes = [ block, 'menu-level-' ~ menu_level ] %}
 
-    <ul{{ attributes.addClass(classes) }} aria-expanded="false">
+    <ul{{ attributes.addClass(classes) }}>
 
-    {% if menu_level > 0 %}
+      {% if menu_level > 0 %}
 
-      <li class="back-link">
-        <a aria-label="{{ 'Back to @parent'|t({ '@parent' : parent }) }}" href="#">
-          {{ 'Back to @parent'|t({ '@parent' : parent }) }}
-        </a>
-      </li>
-
-      {% if parent_link %}
-        <li class="parent-link">
-          {{ parent_link }}
+        <li class="back-link">
+          <a aria-label="{{ 'Back to @parent'|t({ '@parent' : parent }) }}" href="#">
+            {{ 'Back to @parent'|t({ '@parent' : parent }) }}
+          </a>
         </li>
-      {% endif %}
 
-    {% endif %}
-
-    {% for item in items %}
-
-      {% set li_classes = [] %}
-
-      {% if item.below %}
-        {% set li_classes = li_classes|merge(['has-submenu']) %}
-      {% endif %}
-
-      <li{{ item.attributes.addClass(li_classes) }}>
-
-        {{ link(item.title, item.url) }}
-
-        {% if item.below %}
-          <div class="submenu-wrapper">
-            {{ menus.menu_links(item.below, create_attribute(), menu_level + 1, item.title, trigger_item_title, link(item.title, item.url)) }}
-          </div>
+        {% if parent_link %}
+          <li class="parent-link">
+            {{ parent_link }}
+          </li>
         {% endif %}
 
-      </li>
+      {% endif %}
 
-    {% endfor %}
+      {% for item in items %}
+
+        {% set li_classes = [] %}
+
+        {% if item.below %}
+          {% set li_classes = li_classes|merge(['has-submenu']) %}
+        {% endif %}
+
+        <li{{ item.attributes.addClass(li_classes) }}>
+          {% if item.below %}
+            {{ link(item.title, item.url, { 'aria-expanded': 'false'}) }}
+            <div class="submenu-wrapper">
+              {{ menus.menu_links(item.below, create_attribute(), menu_level + 1, item.title, trigger_item_title, link(item.title, item.url)) }}
+            </div>
+          {% else %}
+            {{ link(item.title, item.url) }}
+          {% endif %}
+        </li>
+
+      {% endfor %}
 
     </ul>
   {% endif %}

--- a/themes/wilson_theme_starterkit/templates/navigation/pager.html.twig
+++ b/themes/wilson_theme_starterkit/templates/navigation/pager.html.twig
@@ -1,3 +1,35 @@
+{#
+/**
+ * @file
+ * Theme override to display a pager.
+ *
+ * Available variables:
+ * - heading_id: Pagination heading ID.
+ * - items: List of pager items.
+ *   The list is keyed by the following elements:
+ *   - first: Item for the first page; not present on the first page of results.
+ *   - previous: Item for the previous page; not present on the first page
+ *     of results.
+ *   - next: Item for the next page; not present on the last page of results.
+ *   - last: Item for the last page; not present on the last page of results.
+ *   - pages: List of pages, keyed by page number.
+ *   Sub-sub elements:
+ *   items.first, items.previous, items.next, items.last, and each item inside
+ *   items.pages contain the following elements:
+ *   - href: URL with appropriate query parameters for the item.
+ *   - attributes: A keyed list of HTML attributes for the item.
+ *   - text: The visible text used for the item link, such as "‹ Previous"
+ *     or "Next ›".
+ * - current: The page number of the current page.
+ * - ellipses: If there are more pages than the quantity allows, then an
+ *   ellipsis before or after the listed pages may be present.
+ *   - previous: Present if the currently visible list of pages does not start
+ *     at the first page.
+ *   - next: Present if the visible list of pages ends before the last page.
+ *
+ * @see template_preprocess_pager()
+ */
+#}
 {% if items %}
   <nav class="pager mt-16" role="navigation" aria-labelledby="{{ heading_id }}">
     <h4 id="{{ heading_id }}" class="visually-hidden">{{ 'Pagination'|t }}</h4>

--- a/themes/wilson_theme_starterkit/templates/paragraph/paragraph--accordion.html.twig
+++ b/themes/wilson_theme_starterkit/templates/paragraph/paragraph--accordion.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Default theme implementation to display a paragraph.
+ * Default theme implementation to display an accordion paragraph.
  *
  * Available variables:
  * - paragraph: Full paragraph entity.

--- a/themes/wilson_theme_starterkit/templates/paragraph/paragraph--block.html.twig
+++ b/themes/wilson_theme_starterkit/templates/paragraph/paragraph--block.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Default theme implementation to display a paragraph.
+ * Default theme implementation to display a block paragraph.
  *
  * Available variables:
  * - paragraph: Full paragraph entity.

--- a/themes/wilson_theme_starterkit/templates/paragraph/paragraph--button-grid.html.twig
+++ b/themes/wilson_theme_starterkit/templates/paragraph/paragraph--button-grid.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Default theme implementation to display a paragraph.
+ * Default theme implementation to display a button grid paragraph.
  *
  * Available variables:
  * - paragraph: Full paragraph entity.

--- a/themes/wilson_theme_starterkit/templates/paragraph/paragraph--content-grid.html.twig
+++ b/themes/wilson_theme_starterkit/templates/paragraph/paragraph--content-grid.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Default theme implementation to display a paragraph.
+ * Default theme implementation to display a content grid paragraph.
  *
  * Available variables:
  * - paragraph: Full paragraph entity.

--- a/themes/wilson_theme_starterkit/templates/paragraph/paragraph--content-slider.html.twig
+++ b/themes/wilson_theme_starterkit/templates/paragraph/paragraph--content-slider.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Default theme implementation to display a paragraph.
+ * Default theme implementation to display a content slider paragraph.
  *
  * Available variables:
  * - paragraph: Full paragraph entity.
@@ -78,8 +78,12 @@
       </div>
 
       <div class="glide__arrows flex flex-row mt-8" data-glide-el="controls">
-        <button class="glide__arrow glide__arrow--left px-4 border-2 inline-block text-lg rounded-l-3xl focus:outline-none hover:shadow-halo" data-glide-dir="<">←</button>
-        <button class="glide__arrow glide__arrow--right px-4 border-2 inline-block border-l-0 text-lg rounded-r-3xl focus:outline-none hover:shadow-halo" data-glide-dir=">">→</button>
+        <button class="glide__arrow glide__arrow--left px-4 border-2 inline-block text-lg rounded-l-3xl hover:shadow-halo" data-glide-dir="<" type="button">
+          &#8592;<span class="visually-hidden">{{ 'Previous'|t }}</span>
+        </button>
+        <button class="glide__arrow glide__arrow--right px-4 border-2 inline-block border-l-0 text-lg rounded-r-3xl hover:shadow-halo" data-glide-dir=">" type="button">
+          &#8594;<span class="visually-hidden">{{ 'Next'|t }}</span>
+        </button>
       </div>
     </div>
   </div>

--- a/themes/wilson_theme_starterkit/templates/paragraph/paragraph--gallery.html.twig
+++ b/themes/wilson_theme_starterkit/templates/paragraph/paragraph--gallery.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Default theme implementation to display a paragraph.
+ * Default theme implementation to display a gallery paragraph.
  *
  * Available variables:
  * - paragraph: Full paragraph entity.
@@ -61,7 +61,9 @@
 
         <div class="glide__controls flex justify-center mt-8 pb-2" data-glide-el="controls[nav]">
           {% for item in content.field_media|field_value %}
-            <button class="h-4 w-4 mx-2 relative border-2 rounded-full transition-all outline-none focus:outline-none hover:shadow-halo" data-glide-dir="={{ loop.index0 }}"></button>
+            <button class="h-4 w-4 mx-2 relative border-2 rounded-full transition-all hover:shadow-halo" data-glide-dir="={{ loop.index0 }}" type="button">
+              <span class="visually-hidden">{{ 'Go to slide' }} {{ loop.index }}</span>
+            </button>
           {% endfor %}
         </div>
       </div>

--- a/themes/wilson_theme_starterkit/templates/paragraph/paragraph--hero.html.twig
+++ b/themes/wilson_theme_starterkit/templates/paragraph/paragraph--hero.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Default theme implementation to display a paragraph.
+ * Default theme implementation to display a hero paragraph.
  *
  * Available variables:
  * - paragraph: Full paragraph entity.

--- a/themes/wilson_theme_starterkit/templates/paragraph/paragraph--item--accordion.html.twig
+++ b/themes/wilson_theme_starterkit/templates/paragraph/paragraph--item--accordion.html.twig
@@ -1,7 +1,46 @@
+{#
+/**
+ * @file
+ * Default theme implementation to display an accordion item paragraph.
+ *
+ * Available variables:
+ * - paragraph: Full paragraph entity.
+ *   Only method names starting with "get", "has", or "is" and a few common
+ *   methods such as "id", "label", and "bundle" are available. For example:
+ *   - paragraph.getCreatedTime() will return the paragraph creation timestamp.
+ *   - paragraph.id(): The paragraph ID.
+ *   - paragraph.bundle(): The type of the paragraph, for example, "image" or "text".
+ *   - paragraph.getOwnerId(): The user ID of the paragraph author.
+ *   See Drupal\paragraphs\Entity\Paragraph for a full list of public properties
+ *   and methods for the paragraph object.
+ * - content: All paragraph items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - paragraphs: The current template type (also known as a "theming hook").
+ *   - paragraphs--type-[type]: The current paragraphs type. For example, if the paragraph is an
+ *     "Image" it would result in "paragraphs--type--image". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - paragraphs--view-mode--[view_mode]: The View Mode of the paragraph; for example, a
+ *     preview would result in: "paragraphs--view-mode--preview", and
+ *     default: "paragraphs--view-mode--default".
+ * - view_mode: View mode; for example, "preview" or "full".
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status. Will be true when the current user
+ *   is an administrator.
+ *
+ * @see template_preprocess_paragraph()
+ *
+ * @ingroup themeable
+ */
+#}
 {% block paragraph %}
-
   <h3 class="panels__title py-4 border-t my-0 relative text-lg font-semibold flex cursor-pointer"{{ create_attribute({ 'id': attributes.id }) }}>
-    <button class="text-left font-semibold flex-grow">{{ content.field_headline|field_value }}</button>
+    <button class="panels__button text-left font-semibold flex-grow" type="button" aria-expanded="false" aria-controls="{{ attributes.id }}-content">{{ content.field_headline|field_value }}</button>
     <svg class="open flex-shrink-0 w-6 ml-2" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v3m0 0v3m0-3h3m-3 0H9m12 0a9 9 0 11-18 0 9 9 0 0118 0z" />
     </svg>
@@ -9,8 +48,7 @@
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12H9m12 0a9 9 0 11-18 0 9 9 0 0118 0z" />
     </svg>
   </h3>
-  <div role="region" class="panels__panel pb-6" aria-expanded="false">
+  <div role="region" class="panels__panel pb-6" id="{{ attributes.id }}-content">
     {{ content.field_text_column|field_value }}
   </div>
-
 {% endblock paragraph %}

--- a/themes/wilson_theme_starterkit/templates/paragraph/paragraph--item--tab.html.twig
+++ b/themes/wilson_theme_starterkit/templates/paragraph/paragraph--item--tab.html.twig
@@ -40,7 +40,7 @@
 #}
 {% block paragraph %}
   <h3 class="panels__title py-4 border-t my-0 relative text-lg font-semibold flex cursor-pointer"{{ create_attribute({ 'id': attributes.id }) }}>
-    <button class="panels__button text-left font-semibold flex-grow focus:outline-none" aria-expanded="false" type="button">{{ content.field_headline|field_value }}</button>
+    <button class="panels__button text-left font-semibold flex-grow focus:outline-none" aria-expanded="false" aria-controls="{{ attributes.id }}-content" type="button">{{ content.field_headline|field_value }}</button>
     <span class="open text-2xl flex-shrink-0 ml-2">⬎</span>
     <span class="close text-2xl flex-shrink-0 ml-2">⬏</span>
   </h3>

--- a/themes/wilson_theme_starterkit/templates/paragraph/paragraph--item--tab.html.twig
+++ b/themes/wilson_theme_starterkit/templates/paragraph/paragraph--item--tab.html.twig
@@ -1,12 +1,50 @@
+{#
+/**
+ * @file
+ * Default theme implementation to display a tab item paragraph.
+ *
+ * Available variables:
+ * - paragraph: Full paragraph entity.
+ *   Only method names starting with "get", "has", or "is" and a few common
+ *   methods such as "id", "label", and "bundle" are available. For example:
+ *   - paragraph.getCreatedTime() will return the paragraph creation timestamp.
+ *   - paragraph.id(): The paragraph ID.
+ *   - paragraph.bundle(): The type of the paragraph, for example, "image" or "text".
+ *   - paragraph.getOwnerId(): The user ID of the paragraph author.
+ *   See Drupal\paragraphs\Entity\Paragraph for a full list of public properties
+ *   and methods for the paragraph object.
+ * - content: All paragraph items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - paragraphs: The current template type (also known as a "theming hook").
+ *   - paragraphs--type-[type]: The current paragraphs type. For example, if the paragraph is an
+ *     "Image" it would result in "paragraphs--type--image". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - paragraphs--view-mode--[view_mode]: The View Mode of the paragraph; for example, a
+ *     preview would result in: "paragraphs--view-mode--preview", and
+ *     default: "paragraphs--view-mode--default".
+ * - view_mode: View mode; for example, "preview" or "full".
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status. Will be true when the current user
+ *   is an administrator.
+ *
+ * @see template_preprocess_paragraph()
+ *
+ * @ingroup themeable
+ */
+#}
 {% block paragraph %}
-
   <h3 class="panels__title py-4 border-t my-0 relative text-lg font-semibold flex cursor-pointer"{{ create_attribute({ 'id': attributes.id }) }}>
-    <button class="text-left font-semibold flex-grow focus:outline-none">{{ content.field_headline|field_value }}</button>
+    <button class="panels__button text-left font-semibold flex-grow focus:outline-none" aria-expanded="false" type="button">{{ content.field_headline|field_value }}</button>
     <span class="open text-2xl flex-shrink-0 ml-2">⬎</span>
     <span class="close text-2xl flex-shrink-0 ml-2">⬏</span>
   </h3>
-  <div role="region" class="panels__panel pb-6 mb:pb-0" aria-expanded="false">
+  <div role="region" class="panels__panel pb-6 mb:pb-0">
     {{ content.field_text_column|field_value }}
   </div>
-
 {% endblock paragraph %}

--- a/themes/wilson_theme_starterkit/templates/paragraph/paragraph--logo-wall.html.twig
+++ b/themes/wilson_theme_starterkit/templates/paragraph/paragraph--logo-wall.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Default theme implementation to display a paragraph.
+ * Default theme implementation to display a logo wall paragraph.
  *
  * Available variables:
  * - paragraph: Full paragraph entity.

--- a/themes/wilson_theme_starterkit/templates/paragraph/paragraph--map.html.twig
+++ b/themes/wilson_theme_starterkit/templates/paragraph/paragraph--map.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Default theme implementation to display a paragraph.
+ * Default theme implementation to display a map paragraph.
  *
  * Available variables:
  * - paragraph: Full paragraph entity.

--- a/themes/wilson_theme_starterkit/templates/paragraph/paragraph--one-column.html.twig
+++ b/themes/wilson_theme_starterkit/templates/paragraph/paragraph--one-column.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Default theme implementation to display a paragraph.
+ * Default theme implementation to display a one column paragraph.
  *
  * Available variables:
  * - paragraph: Full paragraph entity.

--- a/themes/wilson_theme_starterkit/templates/paragraph/paragraph--panel.html.twig
+++ b/themes/wilson_theme_starterkit/templates/paragraph/paragraph--panel.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Default theme implementation to display a paragraph.
+ * Default theme implementation to display a panel paragraph.
  *
  * Available variables:
  * - paragraph: Full paragraph entity.

--- a/themes/wilson_theme_starterkit/templates/paragraph/paragraph--quote.html.twig
+++ b/themes/wilson_theme_starterkit/templates/paragraph/paragraph--quote.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Default theme implementation to display a paragraph.
+ * Default theme implementation to display a quote paragraph.
  *
  * Available variables:
  * - paragraph: Full paragraph entity.

--- a/themes/wilson_theme_starterkit/templates/paragraph/paragraph--simple-banner.html.twig
+++ b/themes/wilson_theme_starterkit/templates/paragraph/paragraph--simple-banner.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Default theme implementation to display a paragraph.
+ * Default theme implementation to display a simple banner paragraph.
  *
  * Available variables:
  * - paragraph: Full paragraph entity.

--- a/themes/wilson_theme_starterkit/templates/paragraph/paragraph--tabs.html.twig
+++ b/themes/wilson_theme_starterkit/templates/paragraph/paragraph--tabs.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Default theme implementation to display a paragraph.
+ * Default theme implementation to display a tabs paragraph.
  *
  * Available variables:
  * - paragraph: Full paragraph entity.

--- a/themes/wilson_theme_starterkit/templates/paragraph/paragraph--text-webform.html.twig
+++ b/themes/wilson_theme_starterkit/templates/paragraph/paragraph--text-webform.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Default theme implementation to display a paragraph.
+ * Default theme implementation to display a webform paragraph.
  *
  * Available variables:
  * - paragraph: Full paragraph entity.

--- a/themes/wilson_theme_starterkit/templates/paragraph/paragraph--three-columns.html.twig
+++ b/themes/wilson_theme_starterkit/templates/paragraph/paragraph--three-columns.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Default theme implementation to display a paragraph.
+ * Default theme implementation to display a three column paragraph.
  *
  * Available variables:
  * - paragraph: Full paragraph entity.

--- a/themes/wilson_theme_starterkit/templates/paragraph/paragraph--two-columns.html.twig
+++ b/themes/wilson_theme_starterkit/templates/paragraph/paragraph--two-columns.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Default theme implementation to display a paragraph.
+ * Default theme implementation to display a two column paragraph.
  *
  * Available variables:
  * - paragraph: Full paragraph entity.

--- a/themes/wilson_theme_starterkit/templates/paragraph/paragraph--views.html.twig
+++ b/themes/wilson_theme_starterkit/templates/paragraph/paragraph--views.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Default theme implementation to display a paragraph.
+ * Default theme implementation to display a views paragraph.
  *
  * Available variables:
  * - paragraph: Full paragraph entity.

--- a/themes/wilson_theme_starterkit/templates/paragraph/paragraph--webform-embed.html.twig
+++ b/themes/wilson_theme_starterkit/templates/paragraph/paragraph--webform-embed.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Default theme implementation to display a paragraph.
+ * Default theme implementation to display a webform embed paragraph.
  *
  * Available variables:
  * - paragraph: Full paragraph entity.

--- a/themes/wilson_theme_starterkit/templates/views/views-view-unformatted--article.html.twig
+++ b/themes/wilson_theme_starterkit/templates/views/views-view-unformatted--article.html.twig
@@ -1,4 +1,21 @@
-{% set content_classes = [
+{#
+/**
+ * @file
+ * Theme override to display a view of unformatted article rows.
+ *
+ * Available variables:
+ * - title: The title of this group of rows. May be empty.
+ * - rows: A list of the view's row items.
+ *   - attributes: The row's HTML attributes.
+ *   - content: The row's content.
+ * - view: The view object.
+ * - default_row_class: A flag indicating whether default classes should be
+ *   used on rows.
+ *
+ * @see template_preprocess_views_view_unformatted()
+ */
+#}
+ {% set content_classes = [
   'grid',
   'gap-10',
   'grid-cols-1',


### PR DESCRIPTION
**Background / Motivation**

* `aria-expanded` was added to the element that will be displayed / hidden, rather on the [element that controls that behaviour](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-expanded)
* Gallery and slider buttons were missing visually hidden text
* Gallery and slider buttons were missing focus indicator states

**Approach**

* Updated various template and script files to update how `aria-expanded` is added
* Added visually hidden button text 
* Removed `outline: 0` from buttons to revert to default focus styles

**Additional work**

* Added `aria-controls` to tab and accordion controls
* Added and updated template docblocks
* Removed necessary `role` semantics on page elements