### PR TITLE
Bash script to automate setting up a custom theme for Wilson

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ ddev launch
 
 See the README file in the `wilson_theme_starterkit` for more information about the theme and the NPM commands available.
 
-Step 8: Set the new custom theme as the default frontend theme at Manage > Appearance in the Drupal UI.
+**Step 8:** Set the new custom theme as the default frontend theme at Manage > Appearance in the Drupal UI.
 
 ## Drupal quick start (optional)
 

--- a/README.md
+++ b/README.md
@@ -4,50 +4,57 @@ Wilson is the Access in-house installation profile and theme starterkit for Drup
 
 ## Install with Composer
 
-Step 1: Create a project with the Drupal recommended composer profile.
+**Step 1:** Create a project with the Drupal recommended composer profile.
 
-```
+```bash
 composer create-project drupal/recommended-project my-project
 ```
 
-Step 2: Inform Composer of our Wilson GitHub repo.
+**Step 2:** Inform Composer of our Wilson GitHub repo.
 
-```
+```bash
 cd my-project
 composer config repositories.wilson vcs https://github.com/accessdigital/wilson
 ```
 
-Step 3: Change the Composer minimum stability requirement to account for the dev contrib modules we need.
+**Step 3:** Change the Composer minimum stability requirement to account for the dev contrib modules we need.
 
-```
+```bash
 composer config minimum-stability dev
 ```
 
-Step 4: Composer require the Wilson profile (includes the starterkit theme and contrib dependencies).
+**Step 4:** Composer require the Wilson profile (includes the starterkit theme and contrib dependencies).
 
-```
+```bash
 composer require accessdigital/wilson
 ```
+**Step 5:** Setup your project to use a DDEV virtual environment (recommended).
 
-Step 5: Run the Drupal installer and select the `Wilson` profile.
-
-## Theme
-
-The theme ships as a starterkit and must be cloned and renamed for use in a project. See the README file in the `wilson_theme_starterkit` for more information.
-
-However, for demo purposes, you can use the starterkit theme as-is. You must first compile the theme.
-
+```bash
+ddev config --project-type=drupal9 --docroot=web --project-name=my_project --http-port=88
+ddev start
+ddev launch
 ```
-cd web/profiles/custom/wilson/themes/wilson_theme_starterkit
-npm install && gulp build
-drush cr
+
+**Step 6:** Run the Drupal installer wizard and select the `Wilson` profile. Follow the on-screen steps to configure the initial Drupal setup.
+
+**Step 7:** Create a custom theme for your project by cloning the provided starterkit. You can use our Bash script to automate this, as shown below. You should include the machine name and human readable name of the theme as arguments to this command.
+
+```bash
+./web/profiles/custom/wilson/generate-theme.sh my_project_theme 'My Project Theme'
 ```
+
+**Please note that building the theme requires an up-to-date version of Node and NPM on your environment.**
+
+See the README file in the `wilson_theme_starterkit` for more information about the theme and the NPM commands available.
+
+Step 8: Set the new custom theme as the default frontend theme at Manage > Appearance in the Drupal UI.
 
 ## Drupal quick start (optional)
 
 Following the installation and compiling the theme, you can boot up a local version of Drupal + Wilson for testing and evaluating using the in-built Drupal quick start command:
 
-```
+```bash
 cd /path/to/my-project
 php ./web/core/scripts/drupal quick-start wilson
 ```

--- a/generate-theme.sh
+++ b/generate-theme.sh
@@ -35,7 +35,7 @@ fi
 # Clone the starterkit.
 STARTER_KIT="$SCRIPT_DIR/themes/wilson_theme_starterkit"
 
-printf "\n${YELLOW}## Creating $MACHINE_NAME from the Wilson starerkit${NC}\n"
+printf "\n${YELLOW}## Creating $MACHINE_NAME from the Wilson starterkit${NC}\n"
 cp -R "$STARTER_KIT" "$TARGET_DIR"
 
 # Rename and replace Wilson references in theme.

--- a/generate-theme.sh
+++ b/generate-theme.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+# Get arguments from terminal input.
+MACHINE_NAME=$1
+HUMAN_NAME=$2
+
+# Directory location of this script.
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+# Utility directory locations.
+THEMES_DIR="$SCRIPT_DIR/../../../themes/custom"
+TARGET_DIR="$THEMES_DIR/$MACHINE_NAME"
+
+# Codes for text colouring.
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+printf "\n${YELLOW}##########################################\n##########  WILSON THEME SETUP  ##########\n##########################################${NC}\n\n"
+
+# Create folder for custom themes
+if [ ! -d "$THEMES_DIR" ];
+then
+  printf "\n${YELLOW}## Creating the themes/custom folder${NC}\n"
+  mkdir "$THEMES_DIR"
+fi
+
+if [ -d "$TARGET_DIR" ];
+then
+  printf "\n${RED}## FAILED\n\nCannot create theme because ${YELLOW}$TARGET_DIR${RED} already exists. Please delete the existing theme or choose a different machine name.${NC}\n\n"
+  exit 0
+fi
+
+# Clone the starterkit.
+STARTER_KIT="$SCRIPT_DIR/themes/wilson_theme_starterkit"
+
+printf "\n${YELLOW}## Creating $MACHINE_NAME from the Wilson starerkit${NC}\n"
+cp -R "$STARTER_KIT" "$TARGET_DIR"
+
+# Rename and replace Wilson references in theme.
+printf "\n${YELLOW}## Renaming files within $MACHINE_NAME ${NC}\n"
+mv "$TARGET_DIR"/wilson_theme_starterkit.info.yml "$TARGET_DIR"/"$MACHINE_NAME".info.yml
+mv "$TARGET_DIR"/wilson_theme_starterkit.libraries.yml "$TARGET_DIR"/"$MACHINE_NAME".libraries.yml
+mv "$TARGET_DIR"/wilson_theme_starterkit.theme "$TARGET_DIR"/"$MACHINE_NAME".theme
+
+LC_ALL=C find "$TARGET_DIR" -type f -name '*.*' -exec sed -i '' s/Wilson\ Theme\ Starterkit/"$HUMAN_NAME"/g {} +
+LC_ALL=C find "$TARGET_DIR" -type f -name '*.*' -exec sed -i '' s/wilson_theme_starterkit/"$MACHINE_NAME"/g {} +
+
+# Execute the following inside the target theme directory.
+cd "$TARGET_DIR"
+
+# Install theme dependencies and NPM build.
+printf "\n${YELLOW}## Installating NPM dependencies${NC}\n"
+printf "* Node version on this environment: "
+node -v
+printf "* NPM version on this environment: "
+npm -v
+printf "\n"
+npm install
+
+printf "\n${YELLOW}## Building the theme dist assets${NC}\n"
+npm run build
+
+printf "\n${GREEN}## FINISHED\n\nYou can now enable the ${YELLOW}$HUMAN_NAME${GREEN} theme in Drupal at Manage > Appearance.${NC}\n\n"

--- a/generate-theme.sh
+++ b/generate-theme.sh
@@ -51,7 +51,7 @@ LC_ALL=C find "$TARGET_DIR" -type f -name '*.*' -exec sed -i '' s/wilson_theme_s
 cd "$TARGET_DIR"
 
 # Install theme dependencies and NPM build.
-printf "\n${YELLOW}## Installating NPM dependencies${NC}\n"
+printf "\n${YELLOW}## Installing NPM dependencies${NC}\n"
 printf "* Node version on this environment: "
 node -v
 printf "* NPM version on this environment: "


### PR DESCRIPTION
This bash script generates a custom theme from the provided Wilson starter kit, using the passed arguments as the machine and human names. It also does the initial NPM install and build.

```
./web/profiles/custom/wilson/generate-theme.sh my_project_theme 'My Project Theme'
```
<img width="799" alt="Screenshot 2022-05-06 at 11 08 02" src="https://user-images.githubusercontent.com/1227987/167111851-575907ab-f9f5-4e6d-ba67-f82b7d2cacf0.png">

Additionally, I updated the Wilson readme with instructions for running this script as well as reference to doing the DDEV setup.