### PR TITLE
Hero layout options & Replace flex with grid utilities & other fixes

### DIFF
--- a/config/install/core.entity_form_display.paragraph.hero.default.yml
+++ b/config/install/core.entity_form_display.paragraph.hero.default.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.paragraph.hero.field_css_classes
     - field.field.paragraph.hero.field_headline
     - field.field.paragraph.hero.field_id_anchor
+    - field.field.paragraph.hero.field_layout
     - field.field.paragraph.hero.field_padding_bottom
     - field.field.paragraph.hero.field_padding_top
     - field.field.paragraph.hero.field_pre_header
@@ -89,6 +90,7 @@ third_party_settings:
         required_fields: true
     group_layout:
       children:
+        - field_layout
         - field_container_height
         - field_container_width
         - field_container_position
@@ -150,7 +152,7 @@ third_party_settings:
         description: ''
         required_fields: true
 _core:
-  default_config_hash: 4DlCQ83YJ8w-owQo65dg7FHNBvRG2-H_-YxABky6nlc
+  default_config_hash: 7iavhPkJ-bgMUVoKY3xyxlbMXDve6aoKDlCpdECkXew
 id: paragraph.hero.default
 targetEntityType: paragraph
 bundle: hero
@@ -158,25 +160,25 @@ mode: default
 content:
   field_aos:
     type: options_select
-    weight: 9
+    weight: 33
     region: content
     settings: {  }
     third_party_settings: {  }
   field_container_height:
     type: options_select
-    weight: 6
+    weight: 30
     region: content
     settings: {  }
     third_party_settings: {  }
   field_container_position:
     type: options_select
-    weight: 8
+    weight: 32
     region: content
     settings: {  }
     third_party_settings: {  }
   field_container_width:
     type: options_select
-    weight: 7
+    weight: 31
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -203,6 +205,12 @@ content:
     settings:
       size: 60
       placeholder: ''
+    third_party_settings: {  }
+  field_layout:
+    type: options_select
+    weight: 29
+    region: content
+    settings: {  }
     third_party_settings: {  }
   field_padding_bottom:
     type: options_select
@@ -242,14 +250,14 @@ content:
     third_party_settings: {  }
   field_section_bg:
     type: media_library_widget
-    weight: 28
+    weight: 31
     region: content
     settings:
       media_types: {  }
     third_party_settings: {  }
   field_section_bg_colour:
     type: options_select
-    weight: 27
+    weight: 30
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/install/core.entity_view_display.paragraph.hero.default.yml
+++ b/config/install/core.entity_view_display.paragraph.hero.default.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.paragraph.hero.field_css_classes
     - field.field.paragraph.hero.field_headline
     - field.field.paragraph.hero.field_id_anchor
+    - field.field.paragraph.hero.field_layout
     - field.field.paragraph.hero.field_padding_bottom
     - field.field.paragraph.hero.field_padding_top
     - field.field.paragraph.hero.field_pre_header
@@ -22,7 +23,7 @@ dependencies:
     - link
     - text
 _core:
-  default_config_hash: Ya13qer1XMOqkqi41-WU9ADvjXrZLJ9LwjJl4XKt6zY
+  default_config_hash: 1cZlXfN3l2FN5hoUeK59FNfOOBWrrODzQjk3WGLKAeA
 id: paragraph.hero.default
 targetEntityType: paragraph
 bundle: hero
@@ -91,6 +92,7 @@ hidden:
   field_container_width: true
   field_css_classes: true
   field_id_anchor: true
+  field_layout: true
   field_padding_bottom: true
   field_padding_top: true
   field_section_bg_colour: true

--- a/config/install/field.field.paragraph.hero.field_layout.yml
+++ b/config/install/field.field.paragraph.hero.field_layout.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_layout
+    - paragraphs.paragraphs_type.hero
+  module:
+    - options
+id: paragraph.hero.field_layout
+field_name: field_layout
+entity_type: paragraph
+bundle: hero
+label: Layout
+description: ''
+required: true
+translatable: true
+default_value:
+  -
+    value: left
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/install/paragraphs.paragraphs_type.hero.yml
+++ b/config/install/paragraphs.paragraphs_type.hero.yml
@@ -10,7 +10,7 @@ third_party_settings:
     paragraphs_categories:
       media: media
 _core:
-  default_config_hash: Dm4WVcbRbGunOHJ0Tk-7fs-MYGYFvGQe4bAat2MlkN8
+  default_config_hash: cwye0aKzv4oDsKTOLSPlYcuZKzm0eP6pFL5yviTuIVY
 id: hero
 label: Hero
 icon_uuid: 664e6bcf-470f-4718-aba3-00c18fc0015c

--- a/content/node/1.yml
+++ b/content/node/1.yml
@@ -74,7 +74,7 @@ default:
               value: 'Profile successfully installed<span class="text-primary">.</span>'
           field_layout:
             -
-              value: justified
+              value: left
           field_padding_bottom:
             -
               value: xl

--- a/content/node/1.yml
+++ b/content/node/1.yml
@@ -72,6 +72,9 @@ default:
           field_headline:
             -
               value: 'Profile successfully installed<span class="text-primary">.</span>'
+          field_layout:
+            -
+              value: justified
           field_padding_bottom:
             -
               value: xl

--- a/content/node/2.yml
+++ b/content/node/2.yml
@@ -67,7 +67,7 @@ default:
               value: 'Page not found'
           field_layout:
             -
-              value: justified
+              value: left
           field_padding_bottom:
             -
               value: xl

--- a/content/node/2.yml
+++ b/content/node/2.yml
@@ -65,6 +65,9 @@ default:
           field_headline:
             -
               value: 'Page not found'
+          field_layout:
+            -
+              value: justified
           field_padding_bottom:
             -
               value: xl

--- a/content/node/3.yml
+++ b/content/node/3.yml
@@ -67,7 +67,7 @@ default:
               value: 'Access denied'
           field_layout:
             -
-              value: justified
+              value: left
           field_padding_bottom:
             -
               value: xl

--- a/content/node/3.yml
+++ b/content/node/3.yml
@@ -65,6 +65,9 @@ default:
           field_headline:
             -
               value: 'Access denied'
+          field_layout:
+            -
+              value: justified
           field_padding_bottom:
             -
               value: xl

--- a/content/node/4.yml
+++ b/content/node/4.yml
@@ -62,6 +62,9 @@ default:
           field_headline:
             -
               value: 'WYSIWYG content styles'
+          field_layout:
+            -
+              value: justified
           field_padding_bottom:
             -
               value: md

--- a/content/node/4.yml
+++ b/content/node/4.yml
@@ -64,7 +64,7 @@ default:
               value: 'WYSIWYG content styles'
           field_layout:
             -
-              value: justified
+              value: left
           field_padding_bottom:
             -
               value: md

--- a/content/node/5.yml
+++ b/content/node/5.yml
@@ -71,6 +71,9 @@ default:
           field_headline:
             -
               value: 'Editorial page layout'
+          field_layout:
+            -
+              value: justified
           field_padding_bottom:
             -
               value: md

--- a/content/node/5.yml
+++ b/content/node/5.yml
@@ -73,7 +73,7 @@ default:
               value: 'Editorial page layout'
           field_layout:
             -
-              value: justified
+              value: left
           field_padding_bottom:
             -
               value: md

--- a/content/node/6.yml
+++ b/content/node/6.yml
@@ -69,6 +69,9 @@ default:
           field_headline:
             -
               value: 'Photo page layout'
+          field_layout:
+            -
+              value: justified
           field_padding_bottom:
             -
               value: md

--- a/content/node/7.yml
+++ b/content/node/7.yml
@@ -1019,7 +1019,7 @@ default:
               value: 'Basic H1 hero'
           field_layout:
             -
-              value: justified
+              value: left
           field_padding_bottom:
             -
               value: md
@@ -1061,7 +1061,7 @@ default:
               value: 'Full screen hero'
           field_layout:
             -
-              value: justified
+              value: left
           field_padding_bottom:
             -
               value: xl
@@ -1222,7 +1222,7 @@ default:
               value: normal
           field_layout:
             -
-              value: justified
+              value: left
           field_padding_bottom:
             -
               value: md
@@ -1301,7 +1301,7 @@ default:
               value: bg-fixed
           field_layout:
             -
-              value: justified
+              value: left
           field_padding_bottom:
             -
               value: md

--- a/content/node/7.yml
+++ b/content/node/7.yml
@@ -78,6 +78,9 @@ default:
           field_headline:
             -
               value: Components
+          field_layout:
+            -
+              value: justified
           field_padding_bottom:
             -
               value: md
@@ -1014,6 +1017,9 @@ default:
           field_headline:
             -
               value: 'Basic H1 hero'
+          field_layout:
+            -
+              value: justified
           field_padding_bottom:
             -
               value: md
@@ -1053,6 +1059,9 @@ default:
           field_headline:
             -
               value: 'Full screen hero'
+          field_layout:
+            -
+              value: justified
           field_padding_bottom:
             -
               value: xl
@@ -1115,6 +1124,9 @@ default:
           field_headline:
             -
               value: 'Full screen hero'
+          field_layout:
+            -
+              value: center
           field_padding_bottom:
             -
               value: xl
@@ -1142,7 +1154,7 @@ default:
               entity: 12db7978-4760-486b-a0e4-6455f523858f
           field_text_column:
             -
-              value: "<p>Caption text.</p>\r\n"
+              value: "<p>This hero has a looping background video.</p>\r\n"
               format: full_html
     -
       entity:
@@ -1179,7 +1191,7 @@ default:
               value: md
           field_text_column:
             -
-              value: "<p>A hero could also be used to inject a large in to the page.</p>\r\n"
+              value: "<p>A hero could also be used to inject a large image in to the page.</p>\r\n"
               format: full_html
     -
       entity:
@@ -1208,6 +1220,9 @@ default:
           field_container_width:
             -
               value: normal
+          field_layout:
+            -
+              value: justified
           field_padding_bottom:
             -
               value: md
@@ -1284,6 +1299,9 @@ default:
           field_css_classes:
             -
               value: bg-fixed
+          field_layout:
+            -
+              value: justified
           field_padding_bottom:
             -
               value: md

--- a/themes/wilson_theme_starterkit/src/js/components/adaptive-panels.js
+++ b/themes/wilson_theme_starterkit/src/js/components/adaptive-panels.js
@@ -25,11 +25,15 @@
         const panels = accordion.querySelectorAll(".panels__panel");
         const tabs = [];
 
-        // Set up a container that may be used to display tabs.
-        const tabsContainer = document.createElement("ul");
+        // Set up a container that will be used to display tab list.
+        const tabsContainer = document.createElement("div");
         tabsContainer.classList.add("panels__tabs");
         tabsContainer.setAttribute("aria-hidden", "true");
-        tabsContainer.setAttribute("role", "tablist");
+
+        // Set up a list that will be used to display tabs.
+        const tabsList = document.createElement("ul");
+        tabsList.classList.add("panels__tabs-list");
+        tabsList.setAttribute("role", "tablist");
 
         const revealPanel = (index) => {
           headings[index].classList.add("is-active");
@@ -58,7 +62,7 @@
           tabLink.appendChild(tabText);
           tabs.push(tabLink);
           tabItem.appendChild(tabLink);
-          tabsContainer.appendChild(tabItem);
+          tabsList.appendChild(tabItem);
 
           // Handle clicks on the tab item.
           tabLink.addEventListener("click", (event) => {
@@ -89,6 +93,7 @@
         // navigation method at higher breakpoints.
         if (accordion.classList.contains("panels--adaptive")) {
           // Display tabs.
+          tabsContainer.prepend(tabsList);
           accordion.prepend(tabsContainer);
 
           // Update ARIA tags for panels.

--- a/themes/wilson_theme_starterkit/src/js/components/background-videos.js
+++ b/themes/wilson_theme_starterkit/src/js/components/background-videos.js
@@ -24,7 +24,7 @@
         video.loop = true;
         video.play();
 
-        video.parentElement.classList.add("opacity-100");
+        video.parentElement.classList.remove("opacity-0");
       });
 
       // Handle Oembed videos.
@@ -44,7 +44,7 @@
           }
         });
 
-        iframe.parentElement.classList.add("opacity-100");
+        iframe.parentElement.classList.remove("opacity-0");
       });
     },
   };

--- a/themes/wilson_theme_starterkit/src/scss/components/adaptive-panels.scss
+++ b/themes/wilson_theme_starterkit/src/scss/components/adaptive-panels.scss
@@ -50,7 +50,7 @@
     }
 
     &.panels--horizontal {
-      .panels__tabs {
+      .panels__tabs-list {
         @apply hidden;
 
         @screen md {
@@ -70,7 +70,7 @@
             @apply w-full;
             @apply block;
             @apply border-b;
-            @apply border-grey-300;
+            @apply opacity-20;
 
             content: "";
           }
@@ -92,17 +92,17 @@
             @apply pt-0;
             @apply pb-3;
             @apply text-lg;
-            @apply text-grey-500;
             @apply font-semibold;
             @apply text-center;
             @apply cursor-pointer;
             @apply border-transparent;
+            @apply opacity-40;
 
             border-bottom-width: 3px;
 
             &.is-active {
-              @apply border-secondary;
-              @apply text-secondary;
+              @apply border-current;
+              @apply opacity-100;
             }
           }
         }
@@ -111,32 +111,39 @@
 
     &.panels--vertical {
       @screen md {
-        @apply -mx-5;
+        @apply grid;
+        @apply grid-cols-3;
+        @apply gap-10;
       }
 
       .panels__tabs {
         @apply hidden;
 
         @screen md {
-          @apply flex;
-          @apply flex-col;
-          @apply w-4/12;
-          @apply px-5;
+          @apply block;
+        }
+      }
+
+      .panels__tabs-list {
+        @screen md {
+          @apply w-full;
+          @apply p-0;
+          @apply m-0;
           @apply sticky;
           @apply top-0;
-          @apply float-left;
+          @apply self-start;
           @apply list-none;
         }
 
         &::before {
           @screen md {
             @apply absolute;
-            @apply left-5;
+            @apply left-0;
             @apply top-0;
             @apply h-full;
             @apply block;
             @apply border-l;
-            @apply border-grey-300;
+            @apply opacity-20;
 
             content: "";
           }
@@ -158,17 +165,17 @@
             @apply pl-4;
             @apply py-2;
             @apply text-lg;
-            @apply text-grey-500;
             @apply font-semibold;
             @apply text-left;
             @apply cursor-pointer;
             @apply border-transparent;
+            @apply opacity-40;
 
             border-left-width: 3px;
 
             &.is-active {
-              @apply border-secondary;
-              @apply text-secondary;
+              @apply border-current;
+              @apply opacity-100;
             }
           }
         }
@@ -177,15 +184,7 @@
       .panels__title,
       .panels__panel {
         @screen md {
-          @apply w-8/12;
-          @apply ml-auto;
-          @apply px-5;
-        }
-
-        &:last-child {
-          @screen md {
-            @apply pb-0;
-          }
+          @apply col-span-2;
         }
       }
     }

--- a/themes/wilson_theme_starterkit/src/scss/styles.scss
+++ b/themes/wilson_theme_starterkit/src/scss/styles.scss
@@ -20,3 +20,22 @@
 // Import Tailwind components & utilities.
 @tailwind components;
 @tailwind utilities;
+
+// Custom CSS variables.
+:root {
+  // Set variables to match the width of grid columns after accounting for gaps.
+  // The size of the gap used (gap-10 = 2.5rem).
+  $grid-gap: 2.5rem;
+
+  // Two column basis.
+  --one-of-two-cols: calc((100% - #{$grid-gap}) / 2 * 1);
+
+  // Three column basis.
+  --one-of-three-cols: calc((100% - (2 * #{$grid-gap})) / 3 * 1);
+  --two-of-three-cols: calc((100% - (2 * #{$grid-gap})) / 3 * 2 + (1 * #{$grid-gap}));
+
+  // Four column basis.
+  --one-of-four-cols: calc((100% - (3 * #{$grid-gap})) / 4 * 1);
+  --two-of-four-cols: calc((100% - (3 * #{$grid-gap})) / 4 * 2 + (1 * #{$grid-gap}));
+  --three-of-four-cols: calc((100% - (3 * #{$grid-gap})) / 4 * 3 + (2 * #{$grid-gap}));
+}

--- a/themes/wilson_theme_starterkit/tailwind.config.js
+++ b/themes/wilson_theme_starterkit/tailwind.config.js
@@ -76,6 +76,30 @@ module.exports = {
         "1/2-screen": "50vh",
         "3/4-screen": "75vh",
       },
+      width: {
+        // Utilities for setting widths to match grid columns with gaps.
+        // See styles.scss for the source of these CSS variables.
+        // Two column basis
+        "1/2-cols": "var(--one-of-two-cols)",
+        // Three column basis
+        "1/3-cols": "var(--one-of-three-cols)",
+        "2/3-cols": "var(--two-of-three-cols)",
+        // Four column basis
+        "1/4-cols": "var(--one-of-four-cols)",
+        "2/4-cols": "var(--two-of-four-cols)",
+        "3/4-cols": "var(--three-of-four-cols)",
+      },
+      gridTemplateColumns: {
+        // Utilities for setting up specific grid column templates.
+        // A [two thirds] | [one third] layout
+        "2-pref-l": "var(--two-of-three-cols) var(--one-of-three-cols)",
+        // A [one third] | [two thirds] layout
+        "2-pref-r": "var(--one-of-three-cols) var(--two-of-three-cols)",
+        // A semi-flexible [two thirds] | [one third] layout
+        "2-pref-l-flex": "minmax(var(--one-of-three-cols), var(--two-of-three-cols)) auto",
+        // A semi-flexible [one thirds] | [two third] layout
+        "2-pref-r-flex": "auto minmax(var(--one-of-three-cols), var(--two-of-three-cols))",
+      }
     },
   },
   plugins: [

--- a/themes/wilson_theme_starterkit/tailwind.config.js
+++ b/themes/wilson_theme_starterkit/tailwind.config.js
@@ -7,7 +7,7 @@ module.exports = {
   content: [
     // Paths where Tailwind should look to build a list of classes.
     "./templates/**/*.html.twig",
-    "./scripts/**/*.js",
+    "./src/js/**/*.js",
     "./*.theme",
   ],
   safelist: [
@@ -16,8 +16,11 @@ module.exports = {
     // might be used through the CMS WYSIWYG editor.
     // See https://tailwindcss.com/docs/content-configuration#safelisting-classes
     "border-b-2",
+    "bg-primary",
+    "bg-secondary",
     "bg-tertiary",
     "bg-fixed",
+    "bg-current",
     "h-6",
     "h-24",
     "h-40",

--- a/themes/wilson_theme_starterkit/templates/content/node--article--full.html.twig
+++ b/themes/wilson_theme_starterkit/templates/content/node--article--full.html.twig
@@ -84,16 +84,16 @@
         <h1 class="my-0">{{ node.title.0.value|check_markup('full_html') }}</h1>
       {% endif %}
 
-      <ul class="list-none p-0 mt-6 -mx-2 -mb-2 flex flex-row flex-wrap">
+      <ul class="list-none p-0 mt-6 flex flex-row flex-wrap gap-3">
         {% if content.field_categories|render %}
           {% for key, item in content.field_categories if key|first != '#' %}
-            <li class="px-2 pb-2">
+            <li>
               <span class="tag tag--primary">{{ item }}</span>
             </li>
           {% endfor %}
         {% endif %}
 
-        <li class="px-2 pb-2">
+        <li>
           <time class="tag tag--tertiary">{{ node.created.value|format_date('long') }}</time>
         </li>
       </ul>

--- a/themes/wilson_theme_starterkit/templates/content/node--article--teaser.html.twig
+++ b/themes/wilson_theme_starterkit/templates/content/node--article--teaser.html.twig
@@ -102,9 +102,9 @@
       {% endif %}
     </div>
 
-    <div class="mt-auto -mx-2 -mb-2 pb-5 px-5 flex flex-row justify-between items-center">
-      <span class="btn btn--secondary mx-2 mb-2">{{ 'Read more'|t }}</span>
-      <time class="font-semibold text-sm mx-2 mb-2">{{ node.created.value|date('j M Y') }}</time>
+    <div class="mt-auto pb-5 px-5 flex flex-row flex-wrap justify-between gap-3 items-center">
+      <span class="btn btn--secondary">{{ 'Read more'|t }}</span>
+      <time class="font-semibold text-sm whitespace-nowrap">{{ node.created.value|date('j M Y') }}</time>
     </div>
   </a>
 </div>

--- a/themes/wilson_theme_starterkit/templates/paragraph/paragraph--hero.html.twig
+++ b/themes/wilson_theme_starterkit/templates/paragraph/paragraph--hero.html.twig
@@ -40,26 +40,36 @@
 #}
 {% extends "paragraph.html.twig" %}
 
+{% set content_classes = [
+  'grid',
+  'gap-10',
+  settings_layout,
+] %}
+
 {% block content %}
-  {% if content.field_pre_header|render %}
-    {{ content.field_pre_header }}
-  {% endif %}
-  {% if content.field_headline|render %}
-    <h1 class="my-0">
-      {{ paragraph.field_headline.0.value|check_markup('full_html') }}
-    </h1>
-  {% endif %}
+  <div{{ create_attribute({'class': content_classes}) }}>
+    <section>
+      {% if content.field_pre_header|render %}
+        {{ content.field_pre_header }}
+      {% endif %}
+      {% if content.field_headline|render %}
+        <h1 class="my-0">
+          {{ paragraph.field_headline.0.value|check_markup('full_html') }}
+        </h1>
+      {% endif %}
 
-  {% if content.field_text_column|render %}
-    <div class="mt-6 text-lg">
-      {{ content.field_text_column }}
-    </div>
-  {% endif %}
+      {% if content.field_text_column|render %}
+        <div class="mt-6 text-lg">
+          {{ content.field_text_column }}
+        </div>
+      {% endif %}
+    </section>
 
-  {% if content.field_primary_cta|render or content.field_secondary_cta|render %}
-    <div class="mt-6 -mb-2 flex flex-wrap gap-4">
-      {{ content.field_primary_cta }}
-      {{ content.field_secondary_cta }}
-    </div>
-  {% endif %}
+    {% if content.field_primary_cta|render or content.field_secondary_cta|render %}
+      <nav class="flex flex-wrap gap-4">
+        {{ content.field_primary_cta }}
+        {{ content.field_secondary_cta }}
+      </nav>
+    {% endif %}
+  </div>
 {% endblock %}

--- a/themes/wilson_theme_starterkit/templates/paragraph/paragraph--logo-wall.html.twig
+++ b/themes/wilson_theme_starterkit/templates/paragraph/paragraph--logo-wall.html.twig
@@ -40,18 +40,16 @@
 #}
 {% extends "paragraph.html.twig" %}
 
+{# Intentially uses flexbox for layout so that we can center justify items. #}
 {% set content_classes = [
   'flex',
   'flex-wrap',
   'justify-center',
-  '-mx-5',
-  '-mb-5',
+  'gap-10',
 ] %}
 
 {% set column_classes = [
   settings_column_width_non_responsive,
-  'px-5',
-  'pb-5',
   'text-center',
   'flex',
   'justify-center',

--- a/themes/wilson_theme_starterkit/templates/paragraph/paragraph--panel.html.twig
+++ b/themes/wilson_theme_starterkit/templates/paragraph/paragraph--panel.html.twig
@@ -65,9 +65,8 @@
 
 {# Content classes #}
 {% set content_classes = [
-  'flex',
-  'flex-wrap',
-  settings_column_order,
+  'grid',
+  'grid-cols-2',
   settings_container_height ? 'min-h-full',
   'overflow-hidden',
   paragraph.field_container_width.0.value == 'full' ? '-mx-5' : '-mx-5 lg:mx-0',
@@ -83,7 +82,7 @@
           <div{{ create_attribute({'class': inner_container_classes}) }}>
             {% block content %}
               <div{{ create_attribute({'class': content_classes, 'id': attributes.id}) }}>
-                <div class="px-5 py-10 md:px-10 lg:p-16 xl:px-20 w-full md:w-6/12 flex justify-center {{ settings_vertical_alignment }}">
+                <div class="px-5 py-10 md:px-10 lg:p-16 xl:px-20 flex justify-center {{ settings_vertical_alignment }}">
                   <div class="w-full max-w-screen-sm" {{ create_attribute({'data-aos': settings_container_aos}) }}>
                     {% if content.field_pre_header|render or content.field_headline|render %}
                       <div class="mb-6">
@@ -107,7 +106,7 @@
                     {% endif %}
                   </div>
                 </div>
-                <div class="w-full md:w-6/12 flex child:w-full image-cover">
+                <div class="w-full image-cover {{ settings_media_order }}">
                   {{ content.field_media_column|field_value }}
                 </div>
               </div>

--- a/themes/wilson_theme_starterkit/templates/paragraph/paragraph--simple-banner.html.twig
+++ b/themes/wilson_theme_starterkit/templates/paragraph/paragraph--simple-banner.html.twig
@@ -41,14 +41,14 @@
 {% extends "paragraph.html.twig" %}
 
 {% set content_classes = [
-  '-my-2',
-  '-mx-5',
+  'grid',
+  'gap-10',
   settings_layout,
 ] %}
 
 {% block content %}
   <div{{ create_attribute({'class': content_classes}) }}>
-    <div class="py-2 px-5 w-full md:w-auto">
+    <section>
       {% if content.field_pre_header|render %}
         {{ content.field_pre_header }}
       {% endif %}
@@ -62,15 +62,13 @@
           {{ content.field_text_column|field_value }}
         </div>
       {% endif %}
-    </div>
+    </section>
 
     {% if content.field_primary_cta|render or content.field_secondary_cta|render %}
-      <div class="py-2 px-5 w-full md:w-auto md:flex-shrink-0">
-        <nav class="flex flex-wrap gap-4">
-          {{ content.field_primary_cta }}
-          {{ content.field_secondary_cta }}
-        </div>
-      </div>
+      <nav class="flex flex-wrap gap-4">
+        {{ content.field_primary_cta }}
+        {{ content.field_secondary_cta }}
+      </nav>
     {% endif %}
   </div>
 {% endblock %}

--- a/themes/wilson_theme_starterkit/templates/paragraph/paragraph--text-webform.html.twig
+++ b/themes/wilson_theme_starterkit/templates/paragraph/paragraph--text-webform.html.twig
@@ -41,18 +41,16 @@
 {% extends "paragraph.html.twig" %}
 
 {% set content_classes = [
-  'flex',
-  'flex-wrap',
-  '-mx-5',
-  '-mb-6',
+  'grid',
+  'md:grid-cols-2',
+  'gap-10',
   settings_vertical_alignment,
-  settings_column_order,
 ] %}
 
 {% block content %}
   <div{{ create_attribute({'class': content_classes}) }}>
     {% if content.field_text_column|render %}
-      <div class="px-5 pb-6 w-full md:w-6/12">
+      <div>
         {% if content.field_pre_header|render or content.field_headline|render %}
           <div class="mb-6">
             {% if content.field_pre_header|render %}
@@ -77,7 +75,7 @@
     {% endif %}
 
     {% if content.field_webform|render %}
-      <div class="px-5 pb-6 w-full md:w-6/12">
+      <div{{ create_attribute({'class': settings_media_order}) }}>
         <div class="p-6 shadow-mg lg:shadow-lg rounded-lg overflow-hidden p-5 bg-grey-50 text-black border border-grey-300">
           {{ content.field_webform|field_value }}
         </div>

--- a/themes/wilson_theme_starterkit/templates/paragraph/paragraph--three-columns.html.twig
+++ b/themes/wilson_theme_starterkit/templates/paragraph/paragraph--three-columns.html.twig
@@ -41,29 +41,28 @@
 {% extends "paragraph.html.twig" %}
 
 {% set content_classes = [
-  'flex',
-  'flex-wrap',
-  '-mx-5',
-  '-mb-6',
+  'grid',
+  'md:grid-cols-3',
+  'gap-10',
   settings_vertical_alignment,
 ] %}
 
 {% block content %}
   <div{{ create_attribute({'class': content_classes}) }}>
     {% if content.field_text_column|render %}
-      <div class="px-5 pb-6 w-full md:w-4/12">
+      <div>
         {{ content.field_text_column|field_value }}
       </div>
     {% endif %}
 
     {% if content.field_text_column_2|render %}
-      <div class="px-5 pb-6 w-full md:w-4/12">
+      <div>
         {{ content.field_text_column_2|field_value }}
       </div>
     {% endif %}
 
     {% if content.field_text_column_3|render %}
-      <div class="px-5 pb-6 w-full md:w-4/12">
+      <div>
         {{ content.field_text_column_3|field_value }}
       </div>
     {% endif %}

--- a/themes/wilson_theme_starterkit/templates/paragraph/paragraph--two-columns.html.twig
+++ b/themes/wilson_theme_starterkit/templates/paragraph/paragraph--two-columns.html.twig
@@ -47,25 +47,26 @@
 ] %}
 
 {% if paragraph.field_column_distribution.0.value == 'preference_left' %}
-  {% set content_classes = content_classes|merge(['md:grid-cols-3']) %}
-  {% set col_1_class = 'md:col-span-2' %}
+  {# Use a grid template [two thirds] | [one third] #}
+  {% set content_classes = content_classes|merge(['md:grid-cols-2-pref-l']) %}
 {% elseif paragraph.field_column_distribution.0.value == 'preference_right' %}
-  {% set content_classes = content_classes|merge(['md:grid-cols-3']) %}
-  {% set col_2_class = 'md:col-span-2' %}
+  {# Use a grid template [one third] | [two thirds] #}
+  {% set content_classes = content_classes|merge(['md:grid-cols-2-pref-r']) %}
 {% else %}
+  {# Use a grid template with two equal sized columns #}
   {% set content_classes = content_classes|merge(['md:grid-cols-2']) %}
 {% endif %}
 
 {% block content %}
   <div{{ create_attribute({'class': content_classes}) }}>
     {% if content.field_text_column|render %}
-      <div{{ create_attribute({'class': col_1_class}) }}>
+      <div>
         {{ content.field_text_column|field_value }}
       </div>
     {% endif %}
 
     {% if content.field_text_column_2|render %}
-      <div{{ create_attribute({'class': col_2_class}) }}>
+      <div>
         {{ content.field_text_column_2|field_value }}
       </div>
     {% endif %}

--- a/themes/wilson_theme_starterkit/templates/paragraph/paragraph--two-columns.html.twig
+++ b/themes/wilson_theme_starterkit/templates/paragraph/paragraph--two-columns.html.twig
@@ -41,34 +41,31 @@
 {% extends "paragraph.html.twig" %}
 
 {% set content_classes = [
-  'flex',
-  'flex-wrap',
-  '-mx-5',
-  '-mb-6',
+  'grid',
+  'gap-10',
   settings_vertical_alignment,
 ] %}
 
 {% if paragraph.field_column_distribution.0.value == 'preference_left' %}
-  {% set col_1_class = 'md:w-8/12' %}
-  {% set col_2_class = 'md:w-4/12' %}
+  {% set content_classes = content_classes|merge(['md:grid-cols-3']) %}
+  {% set col_1_class = 'md:col-span-2' %}
 {% elseif paragraph.field_column_distribution.0.value == 'preference_right' %}
-  {% set col_1_class = 'md:w-4/12' %}
-  {% set col_2_class = 'md:w-8/12' %}
+  {% set content_classes = content_classes|merge(['md:grid-cols-3']) %}
+  {% set col_2_class = 'md:col-span-2' %}
 {% else %}
-  {% set col_1_class = 'md:w-6/12' %}
-  {% set col_2_class = 'md:w-6/12' %}
+  {% set content_classes = content_classes|merge(['md:grid-cols-2']) %}
 {% endif %}
 
 {% block content %}
   <div{{ create_attribute({'class': content_classes}) }}>
     {% if content.field_text_column|render %}
-      <div class="px-5 pb-6 w-full {{ col_1_class }}">
+      <div{{ create_attribute({'class': col_1_class}) }}>
         {{ content.field_text_column|field_value }}
       </div>
     {% endif %}
 
     {% if content.field_text_column_2|render %}
-      <div class="px-5 pb-6 w-full {{ col_2_class }}">
+      <div{{ create_attribute({'class': col_2_class}) }}>
         {{ content.field_text_column_2|field_value }}
       </div>
     {% endif %}

--- a/themes/wilson_theme_starterkit/templates/paragraph/paragraph.html.twig
+++ b/themes/wilson_theme_starterkit/templates/paragraph/paragraph.html.twig
@@ -45,8 +45,8 @@
   'section--' ~ paragraph.bundle|clean_class,
   has_bg_image ? 'section-bg bg-center bg-no-repeat bg-cover',
   background_colour_classes,
-  'overflow-hidden',
   has_video or has_remote_video ? 'section-bg-video relative',
+  paragraph.bundle == "content_slider" ? 'overflow-hidden',
 ] %}
 
 {# Container classes #}

--- a/themes/wilson_theme_starterkit/wilson_theme_starterkit.theme
+++ b/themes/wilson_theme_starterkit/wilson_theme_starterkit.theme
@@ -124,11 +124,11 @@ function wilson_theme_starterkit_preprocess_paragraph(&$variables) {
   if ($paragraph->hasField('field_column_order')) {
     $value = $paragraph->get('field_column_order')->getString();
     $map = [
-      'text_media' => 'flex-col md:flex-row',
-      'media_text' => 'flex-col md:flex-row-reverse',
+      'text_media' => '',
+      'media_text' => 'order-first',
     ];
 
-    $variables['settings_column_order'] = $map[$value];
+    $variables['settings_media_order'] = $map[$value];
   }
 
   // Convert field_padding_top value to a tailwind class.

--- a/themes/wilson_theme_starterkit/wilson_theme_starterkit.theme
+++ b/themes/wilson_theme_starterkit/wilson_theme_starterkit.theme
@@ -163,10 +163,14 @@ function wilson_theme_starterkit_preprocess_paragraph(&$variables) {
   if ($paragraph->hasField('field_layout')) {
     $value = $paragraph->get('field_layout')->getString();
     $map = [
-      'justified' => 'flex flex-col md:flex-row md:justify-between items-center',
-      'center' => 'flex flex-col text-center descendant-nav:justify-center',
-      'left' => 'flex flex-col text-left descendant-nav:justify-start',
-      'right' => 'flex flex-col text-right descendant-nav:justify-end',
+      // Justified = a semi-flexible [two thirds] | [one third] layout.
+      'justified' => 'md:grid-cols-2-pref-l-flex md:items-center md:descendant-nav:justify-end',
+      // Center = centre aligned [two thirds] stacked
+      'center' => 'md:w-2/3-cols mx-auto text-center descendant-nav:justify-center',
+      // Left = left aligned [two thirds] stacked
+      'left' => 'md:w-2/3-cols text-left',
+      // Right = right aligned [two thirds] stacked
+      'right' => 'md:w-2/3-cols ml-auto text-right descendant-nav:justify-end',
     ];
 
     $variables['settings_layout'] = $map[$value];


### PR DESCRIPTION
Done as one PR because there were inter-related changes. Sorry for the size but this crosses off a few things on the Wilson wishlist.

Hero
* Add the 'Layout' option field to Hero component (as used on Simple Banner) which allows the editor to justify, center, left align or right align the contents of the hero.
* Limits the line length of hero content to max two thirds width on non-mobile devices.
* Fix issue where video backgrounds remain transparent after loading.

Grid utilities
* Introduces some CSS variables to match the width of grid columns after accounting for gaps, e.g. `--two-of-three-cols`
* Introduces some Tailwind custom width classes that use those variables, e.g. `.w-2/3-cols`
* Introduces some Tailwind custom grid template classes that define asymmetric two column layouts, e.g. `.grid-cols-2-pref-l` (2 columns where the left column is wider than the right)
* Update various templates to use these new utility classes and replace flexbox layouts

Tabs
* Fix the broken sticky position on vertical tabs nav.
* Use border colours that automatically change with the text colour to hopefully maintain contrast when using different backgrounds.

Default content
* Update the default content install files to use the new hero layout setting.

Tailwind config
* Correct the path to the JS files used by Tailwind when determining which classes to include.
* Add some useful background colours to the Tailwind safelist so they can be used safely in the CMS.