### PR TITLE
Offset backdrop support

### DIFF
--- a/themes/wilson_theme_starterkit/src/scss/base/_elements.scss
+++ b/themes/wilson_theme_starterkit/src/scss/base/_elements.scss
@@ -195,4 +195,14 @@
       }
     }
   }
+
+  // Increase the z-index of paragraph contents when the wrapper has
+  // absolute positioned ::before or ::after pseudo elements injected in.
+  .before\:absolute,
+  .after\:absolute {
+    > .section__container {
+      @apply relative;
+      @apply z-1;
+    }
+  }
 }

--- a/themes/wilson_theme_starterkit/tailwind.config.js
+++ b/themes/wilson_theme_starterkit/tailwind.config.js
@@ -45,6 +45,19 @@ module.exports = {
       pattern: /^w-(3\/12|6\/12)/,
       variants: ["md"],
     },
+    // Support for offset backdrops via pseudo elements.
+    {
+      pattern: /^top-|^bottom-|^left-0|^right-0/,
+      variants: ["before", "after"],
+    },
+    {
+      pattern: /absolute/,
+      variants: ["before", "after"],
+    },
+    {
+      pattern: /bg-primary|bg-secondary|bg-tertiary/,
+      variants: ["before", "after"],
+    },
   ],
   theme: {
     colors: {
@@ -113,7 +126,10 @@ module.exports = {
         "2-pref-l-flex": "minmax(var(--one-of-three-cols), var(--two-of-three-cols)) auto",
         // A semi-flexible [one thirds] | [two third] layout
         "2-pref-r-flex": "auto minmax(var(--one-of-three-cols), var(--two-of-three-cols))",
-      }
+      },
+      zIndex: {
+        "1": "1",
+      },
     },
   },
   plugins: [

--- a/themes/wilson_theme_starterkit/tailwind.config.js
+++ b/themes/wilson_theme_starterkit/tailwind.config.js
@@ -46,6 +46,8 @@ module.exports = {
       variants: ["md"],
     },
     // Support for offset backdrops via pseudo elements.
+    // Example classes used on a paragraph:
+    // `relative before:bg-primary before:absolute before:top-1/2 before:right-0 before:bottom-0 before:left-0`
     {
       pattern: /^top-|^bottom-|^left-0|^right-0/,
       variants: ["before", "after"],


### PR DESCRIPTION
**This PR is built on the back of the other open PRs which should be reviewed and merged first.**

Adds relevant classes to the Tailwind safelist to allow the making of "offset backdrops" through the CMS - be that using the Classes field on a component or by creating a custom background style taxonomy term. This first pass is a balance between generic classes for Wilson and not wanting to overly increase the size of the compiled CSS. If a client site built on top of Wilson needs something specific (like more colour options) then that client's theme could be extended.

As an example of what I mean by "offset backdrop" consider the below screenshot. 

* The first floorplan image has a transparent (i.e. white) background and then a yellow 50% high `::before` element offset to the bottom of the section.
Uses classes `relative before:bg-primary before:absolute before:top-1/2 before:right-0 before:bottom-0 before:left-0`
* The second floorplan image has a black background with a yellow 50% high `::before` element offset to the top of the section.
Uses classes `relative bg-secondary before:bg-primary before:absolute before:top-0 before:right-0 before:bottom-1/2 before:left-0`

Using different class combinations you could achieve different colour transitions to suit.

![offset-backdrop-example](https://user-images.githubusercontent.com/1227987/191238832-ee506603-7df4-433e-97b9-ac80e5585e23.png)

