### PR TITLE
Accessibility improvements to tab component

### DIFF
--- a/themes/wilson_theme_starterkit/src/js/components/adaptive-panels.js
+++ b/themes/wilson_theme_starterkit/src/js/components/adaptive-panels.js
@@ -83,7 +83,8 @@
             tabs[index].focus();
           };
 
-          // Handle keypress of the tab item - left / right key navigation.
+          // Handle keypress of the tab item - left / right or up / down key
+          // navigation of tabs.
           tabLink.addEventListener("keydown", (event) => {
             const firstTab = 0;
             const lastTab = tabs.length - 1;

--- a/themes/wilson_theme_starterkit/src/js/components/adaptive-panels.js
+++ b/themes/wilson_theme_starterkit/src/js/components/adaptive-panels.js
@@ -38,7 +38,7 @@
           headings[index].classList.add("is-active");
           tabs[index].classList.add("is-active");
           tabs[index].setAttribute("aria-selected", "true");
-          tabs[index].removeAttribute('tabindex');
+          tabs[index].removeAttribute("tabindex");
           panels[index].classList.add("is-active");
           activeIndex = index;
           buttons[index].setAttribute("aria-expanded", "true");
@@ -61,7 +61,12 @@
           const tabText = document.createTextNode(buttons[i].innerText);
           const tabLink = document.createElement("button");
           const tabItem = document.createElement("li");
-          const tabContentID = buttons[i].getAttribute('aria-controls');
+          const tabContentID = buttons[i].getAttribute("aria-controls");
+          let orientation = "horizontal";
+          if (accordion.classList.contains("panels--vertical")) {
+            orientation = "vertical";
+          }
+
           tabLink.setAttribute("role", "tab");
           tabLink.setAttribute("aria-selected", "false");
           tabLink.setAttribute("aria-controls", tabContentID);
@@ -70,9 +75,10 @@
           tabs.push(tabLink);
           tabItem.appendChild(tabLink);
           tabsList.appendChild(tabItem);
+          tabsList.setAttribute("aria-orientation", orientation);
 
           // Select a tab.
-          const setSelectedTab = (index) => {
+          const selectTab = (index) => {
             tabs[index].click();
             tabs[index].focus();
           };
@@ -81,27 +87,36 @@
           tabLink.addEventListener("keydown", (event) => {
             const firstTab = 0;
             const lastTab = tabs.length - 1;
+            const rightDown =
+              orientation === "horizontal" ? "ArrowRight" : "ArrowDown";
+            const leftUp =
+              orientation === "horizontal" ? "ArrowLeft" : "ArrowUp";
+
             switch (event.key) {
-              case 'ArrowRight':
-                // Select first tab in tab list if user tries to move right
-                // beyond the final tab.
+              case rightDown:
+                event.preventDefault();
+                // Select first tab in tab list if user tries to move right (or
+                // down, if vertical tabs) beyond the final tab.
                 if (activeIndex === lastTab) {
-                  setSelectedTab(firstTab);
+                  selectTab(firstTab);
                   // Otherwise, select next tab.
                 } else {
-                  setSelectedTab(activeIndex + 1);
+                  selectTab(activeIndex + 1);
                 }
+
                 break;
 
-              case 'ArrowLeft':
-                // Select final tab in tab list if user tries to move left
-                // beyond the first tab.
+              case leftUp:
+                event.preventDefault();
+                // Select final tab in tab list if user tries to move left (or
+                // up, if vertical tabs) beyond the first tab.
                 if (activeIndex === firstTab) {
-                  setSelectedTab(lastTab);
+                  selectTab(lastTab);
                   // Otherwise, select previous tab.
                 } else {
-                  setSelectedTab(activeIndex - 1);
+                  selectTab(activeIndex - 1);
                 }
+
                 break;
 
               default:

--- a/themes/wilson_theme_starterkit/src/js/components/adaptive-panels.js
+++ b/themes/wilson_theme_starterkit/src/js/components/adaptive-panels.js
@@ -96,12 +96,12 @@
             switch (event.key) {
               case rightDown:
                 event.preventDefault();
-                // Select first tab in tab list if user tries to move right (or
-                // down, if vertical tabs) beyond the final tab.
                 if (activeIndex === lastTab) {
+                  // Select first tab in tab list if user tries to move right (or
+                  // down, if vertical tabs) beyond the final tab.
                   selectTab(firstTab);
-                  // Otherwise, select next tab.
                 } else {
+                  // Otherwise, select next tab.
                   selectTab(activeIndex + 1);
                 }
 
@@ -109,12 +109,12 @@
 
               case leftUp:
                 event.preventDefault();
-                // Select final tab in tab list if user tries to move left (or
-                // up, if vertical tabs) beyond the first tab.
                 if (activeIndex === firstTab) {
+                  // Select final tab in tab list if user tries to move left (or
+                  // up, if vertical tabs) beyond the first tab.
                   selectTab(lastTab);
-                  // Otherwise, select previous tab.
                 } else {
+                  // Otherwise, select previous tab.
                   selectTab(activeIndex - 1);
                 }
 

--- a/themes/wilson_theme_starterkit/src/js/components/adaptive-panels.js
+++ b/themes/wilson_theme_starterkit/src/js/components/adaptive-panels.js
@@ -28,7 +28,6 @@
         // Set up a container that will be used to display tab list.
         const tabsContainer = document.createElement("div");
         tabsContainer.classList.add("panels__tabs");
-        tabsContainer.setAttribute("aria-hidden", "true");
 
         // Set up a list that will be used to display tabs.
         const tabsList = document.createElement("ul");
@@ -38,6 +37,8 @@
         const revealPanel = (index) => {
           headings[index].classList.add("is-active");
           tabs[index].classList.add("is-active");
+          tabs[index].setAttribute("aria-selected", "true");
+          tabs[index].removeAttribute('tabindex');
           panels[index].classList.add("is-active");
           activeIndex = index;
           buttons[index].setAttribute("aria-expanded", "true");
@@ -47,6 +48,8 @@
           if (index !== null) {
             headings[index].classList.remove("is-active");
             tabs[index].classList.remove("is-active");
+            tabs[index].setAttribute("aria-selected", "false");
+            tabs[index].tabIndex = -1;
             panels[index].classList.remove("is-active");
             buttons[index].setAttribute("aria-expanded", "false");
           }
@@ -58,11 +61,53 @@
           const tabText = document.createTextNode(buttons[i].innerText);
           const tabLink = document.createElement("button");
           const tabItem = document.createElement("li");
+          const tabContentID = buttons[i].getAttribute('aria-controls');
           tabLink.setAttribute("role", "tab");
+          tabLink.setAttribute("aria-selected", "false");
+          tabLink.setAttribute("aria-controls", tabContentID);
+          tabLink.tabIndex = -1;
           tabLink.appendChild(tabText);
           tabs.push(tabLink);
           tabItem.appendChild(tabLink);
           tabsList.appendChild(tabItem);
+
+          // Select a tab.
+          const setSelectedTab = (index) => {
+            tabs[index].click();
+            tabs[index].focus();
+          };
+
+          // Handle keypress of the tab item - left / right key navigation.
+          tabLink.addEventListener("keydown", (event) => {
+            const firstTab = 0;
+            const lastTab = tabs.length - 1;
+            switch (event.key) {
+              case 'ArrowRight':
+                // Select first tab in tab list if user tries to move right
+                // beyond the final tab.
+                if (activeIndex === lastTab) {
+                  setSelectedTab(firstTab);
+                  // Otherwise, select next tab.
+                } else {
+                  setSelectedTab(activeIndex + 1);
+                }
+                break;
+
+              case 'ArrowLeft':
+                // Select final tab in tab list if user tries to move left
+                // beyond the first tab.
+                if (activeIndex === firstTab) {
+                  setSelectedTab(lastTab);
+                  // Otherwise, select previous tab.
+                } else {
+                  setSelectedTab(activeIndex - 1);
+                }
+                break;
+
+              default:
+                break;
+            }
+          });
 
           // Handle clicks on the tab item.
           tabLink.addEventListener("click", (event) => {

--- a/themes/wilson_theme_starterkit/src/scss/components/adaptive-panels.scss
+++ b/themes/wilson_theme_starterkit/src/scss/components/adaptive-panels.scss
@@ -50,9 +50,15 @@
     }
 
     &.panels--horizontal {
-      .panels__tabs-list {
+      .panels__tabs {
         @apply hidden;
 
+        @screen md {
+          @apply block;
+        }
+      }
+
+      .panels__tabs-list {
         @screen md {
           @apply flex;
           @apply flex-row;

--- a/themes/wilson_theme_starterkit/templates/paragraph/paragraph--item--tab.html.twig
+++ b/themes/wilson_theme_starterkit/templates/paragraph/paragraph--item--tab.html.twig
@@ -40,11 +40,11 @@
 #}
 {% block paragraph %}
   <h3 class="panels__title py-4 border-t my-0 relative text-lg font-semibold flex cursor-pointer"{{ create_attribute({ 'id': attributes.id }) }}>
-    <button class="panels__button text-left font-semibold flex-grow focus:outline-none" aria-expanded="false" aria-controls="{{ attributes.id }}-content" type="button">{{ content.field_headline|field_value }}</button>
+    <button class="panels__button text-left font-semibold flex-grow" aria-expanded="false" aria-controls="{{ attributes.id }}-content" type="button">{{ content.field_headline|field_value }}</button>
     <span class="open text-2xl flex-shrink-0 ml-2">⬎</span>
     <span class="close text-2xl flex-shrink-0 ml-2">⬏</span>
   </h3>
-  <div role="region" class="panels__panel pb-6 mb:pb-0">
+  <div role="region" class="panels__panel pb-6 mb:pb-0" id="{{ attributes.id }}-content">
     {{ content.field_text_column|field_value }}
   </div>
 {% endblock paragraph %}


### PR DESCRIPTION
### Background / motivation

Improve the accessibility of the adaptive panels, specifically the tabs aspect.

### Keyboard tab navigation

Although previously all tabs and content could be reached using a keyboard, the design pattern wasn't ideal - a user would need to tab through all tab items in order to access content for a particular tab panel. 

To address this, when a user focuses on a tab item, the next item in the tab order is now within the tab panel itself (rather than an adjacent tab).

In order to navigate between tabs items in the tab list:

- The left arrow now moves focus to the previous tab and activates its tab panel. If focuses is already on the first tab, focus is moved to the final tab in the list
- The right arrow now moves focus to next tab and activates its tab panel. If focuses is already on the final tab in the list, focus is moved to the first tab
- If tab orientation is set to vertical, the up arrow mimics the left arrow behaviour and down arrow mimics the right arrow behaviour

### Additional changes

- Added logic to set `aria-selected` to `true` or `false` on tab items depending on whether or not they are selected
- Added `aria-controls` to tab items and ensured attribute value was set as an ID on tab panels so the association between tab and tab panel is clear 
- Removed `aria-hidden` from tab controls - this never appeared to be removed when switching between tab / accordion mode. Modified existing css to show / hide this element instead
- Added `aria-orientation` to tab controls depending on whether tabs are vertical or horizontal
- Removed `outline:none` from tab items to ensure that tab controls have a visible focus state by default 