### PR TITLE
Use the theme CSS within the WYSIWYG text area.

### DIFF
--- a/themes/wilson_theme_starterkit/src/scss/base/_admin.scss
+++ b/themes/wilson_theme_starterkit/src/scss/base/_admin.scss
@@ -1,3 +1,8 @@
+// Add padding when CSS is used inside a WYSIWYG textarea.
+body.cke_editable {
+  @apply p-4 #{!important};
+}
+
 main {
   .contextual-links {
     a {

--- a/themes/wilson_theme_starterkit/wilson_theme_starterkit.info.yml
+++ b/themes/wilson_theme_starterkit/wilson_theme_starterkit.info.yml
@@ -12,7 +12,7 @@ libraries:
   - 'wilson_theme_starterkit/global'
 
 ckeditor_stylesheets:
-  - css/styles.css
+  - dist/css/styles.css
 
 regions:
   header_links: Header Links


### PR DESCRIPTION
I noticed that the WYSIWYG text areas had defaulted back to the default Drupal CSS and weren't pulling in the active theme CSS as expected. Turns out there was a mistake in the theme .info file since the CSS was moved to the `dist` folder.