### PR TITLE
Adding environment_indicator module and initial config.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "drupal/diff": "^1.0",
         "drush/drush": "^11.1",
         "drupal/editor_advanced_link": "^1.8",
+        "drupal/environment_indicator": "^4.0",
         "drupal/field_group": "^3.1",
         "drupal/focal_point": "^1.5",
         "drupal/google_tag": "^1.4",

--- a/config/install/environment_indicator.indicator.yml
+++ b/config/install/environment_indicator.indicator.yml
@@ -1,0 +1,3 @@
+name: Local
+fg_color: '#ffffff'
+bg_color: '#3886c2'

--- a/config/install/environment_indicator.settings.yml
+++ b/config/install/environment_indicator.settings.yml
@@ -1,0 +1,5 @@
+_core:
+  default_config_hash: Bi0EyyiH6m5wpHRfxlKhqTIhAZayhRQudheDzAcrotU
+toolbar_integration:
+  - toolbar
+favicon: true

--- a/config/install/environment_indicator.switcher.dev.yml
+++ b/config/install/environment_indicator.switcher.dev.yml
@@ -1,0 +1,10 @@
+langcode: en
+status: true
+dependencies: {  }
+machine: dev
+description: null
+name: Dev
+weight: '2'
+url: ''
+fg_color: '#ffffff'
+bg_color: '#39b030'

--- a/config/install/environment_indicator.switcher.local.yml
+++ b/config/install/environment_indicator.switcher.local.yml
@@ -1,0 +1,10 @@
+langcode: en
+status: true
+dependencies: {  }
+machine: local
+description: null
+name: Local
+weight: '1'
+url: ''
+fg_color: '#ffffff'
+bg_color: '#3886c2'

--- a/config/install/environment_indicator.switcher.production.yml
+++ b/config/install/environment_indicator.switcher.production.yml
@@ -1,0 +1,10 @@
+langcode: en
+status: true
+dependencies: {  }
+machine: production
+description: null
+name: Production
+weight: '4'
+url: ''
+fg_color: '#ffffff'
+bg_color: '#ce2727'

--- a/config/install/environment_indicator.switcher.stage.yml
+++ b/config/install/environment_indicator.switcher.stage.yml
@@ -1,0 +1,10 @@
+langcode: en
+status: true
+dependencies: {  }
+machine: stage
+description: null
+name: Stage
+weight: '2'
+url: ''
+fg_color: '#ffffff'
+bg_color: '#ea9e1a'

--- a/wilson.info.yml
+++ b/wilson.info.yml
@@ -36,6 +36,8 @@ install:
   - dynamic_page_cache
   - editor
   - editor_advanced_link
+  - environment_indicator
+  - environment_indicator_ui
   - field_group
   - field_ui
   - file


### PR DESCRIPTION
This has been long requested and now Wilson includes [Environment Indicator](https://www.drupal.org/project/environment_indicator).

Though this includes some initial config, it will still be down to the project developers to finish the setup of this. There seems to be two ways this can be configured:-

1. Add environment detection inside the project's `settings.php` file which triggers the correct colouring (see documentation in the module).
2. Use Config Split to override the values of `environment_indicator.indicator.yml` depending on which environmental config is installed. Personally I'd say this is the better route (because it keep everything neatly inside the config system) but Wilson isn't opinionated beyond specifying initial environment colours.

Also, you'll want to update your site config with Acquia/Pantheon/... environment URLs once the project is underway.

<img width="1787" alt="Screenshot 2022-10-10 at 14 20 26" src="https://user-images.githubusercontent.com/1227987/194876294-a0281eb0-9f9e-45bb-a80a-1b1678786701.png">
