### PR TITLE
Refactor main menu JS & styling

### DIFF
--- a/themes/wilson_theme_starterkit/.eslintrc.json
+++ b/themes/wilson_theme_starterkit/.eslintrc.json
@@ -13,7 +13,8 @@
     "Drupal": true,
     "drupalSettings": true,
     "once": true,
-    "countUp": true
+    "countUp": true,
+    "mediaQueryCheck": true
   },
   "settings": {
     "react": {

--- a/themes/wilson_theme_starterkit/src/js/components/main-menu.js
+++ b/themes/wilson_theme_starterkit/src/js/components/main-menu.js
@@ -2,7 +2,7 @@
  * @file
  * Main menu.
  */
-((Drupal) => {
+((Drupal, once) => {
   /**
    * Attaches the main menu behaviour.
    *
@@ -13,102 +13,13 @@
    */
   Drupal.behaviors.mainMenu = {
     attach(context) {
-      // Only progress if there is a menu element to work with.
-      if (context.querySelector(".navigation nav .menu")) {
-        const body = context.querySelector("body");
-        const nav = context.querySelector(".navigation nav");
-        const topLevelMenu = context.querySelector(".navigation .menu");
-        const topLevelSubmenuLinks = context.querySelectorAll(
-          ".navigation .menu > li.has-submenu > a, .navigation .menu > li.has-submenu > span"
-        );
-        const submenuLinks = context.querySelectorAll(
-          ".navigation li.has-submenu > a, .navigation li.has-submenu > span"
-        );
-        const backLinks = context.querySelectorAll(".back-link a");
+      const body = document.querySelector("body");
+      const nav = context.querySelector(".navigation nav");
+      const topLevelMenu = context.querySelector(".navigation .menu");
 
-        // Remove active state from active menu links.
-        const removeActiveLink = (activeLinks) => {
-          Array.prototype.forEach.call(activeLinks, (activeLink) => {
-            activeLink.classList.remove("menu-item-active");
-            if (
-              activeLink.hasAttribute("aria-expanded") &&
-              activeLink.getAttribute("aria-expanded") === "true"
-            ) {
-              activeLink.setAttribute("aria-expanded", "false");
-            }
-          });
-        };
-
-        // Setup event listeners for back links.
-        Array.prototype.forEach.call(backLinks, (backLink) => {
-          const parentWrapper = backLink.closest(".submenu-wrapper");
-          const parentMenuLink = parentWrapper.previousElementSibling;
-
-          backLink.addEventListener("click", (event) => {
-            event.preventDefault();
-            event.stopPropagation();
-
-            parentWrapper.classList.remove("menu-item-active");
-            parentMenuLink.setAttribute("aria-expanded", "false");
-          });
-        });
-
-        Array.prototype.forEach.call(submenuLinks, (link) => {
-          const siblingEl = link.nextElementSibling;
-          const parentEl = link.closest("ul");
-
-          /*
-           * Create event listener to set the submenu as active when the
-           * corresponding link is clicked.
-           */
-          link.addEventListener("click", (event) => {
-            event.preventDefault();
-
-            const activeMenuItems =
-              parentEl.querySelectorAll(".menu-item-active");
-            if (!link.classList.contains("menu-item-active")) {
-              // Remove active state from previously selected links.
-              if (activeMenuItems) {
-                removeActiveLink(activeMenuItems);
-              }
-              // Set the clicked link's submenu to active.
-              link.classList.add("menu-item-active");
-              link.setAttribute("aria-expanded", "true");
-              siblingEl.classList.add("menu-item-active");
-            } else {
-              link.classList.remove("menu-item-active");
-              link.setAttribute("aria-expanded", "false");
-              siblingEl.classList.remove("menu-item-active");
-            }
-          });
-        });
-
-        // Add event listener to top level items with submenus.
-        Array.prototype.forEach.call(topLevelSubmenuLinks, (link) => {
-          // Check for top submenus in the top level menu.
-          const topLevelMenuWrapper = link.nextElementSibling;
-          const submenus = topLevelMenuWrapper.querySelectorAll(
-            ".submenu-wrapper > .menu-level-2"
-          );
-
-          if (submenus.length === 0) {
-            topLevelMenuWrapper.firstElementChild.classList.add("no-submenus");
-          }
-
-          link.addEventListener("click", () => {
-            const activeSubmenus =
-              topLevelMenuWrapper.querySelectorAll(".menu-item-active");
-
-            // Set the child submenus to inactive.
-            if (activeSubmenus.length > 1) {
-              removeActiveLink(activeSubmenus);
-            }
-
-            body.classList.toggle("menu-active");
-          });
-        });
-
-        // Setup mobile header.
+      // Initialise the mobile menu. Populate nav with an additional header containing a menu close button.
+      // @TODO move mobile header in to template so it's easier override without editing this file.
+      once("mobileMenu", "body", context).forEach(() => {
         const menuHeader = document.createElement("div");
         const menuClose = document.createElement("button");
         const menuOpen = document.querySelector(".menu-open");
@@ -119,52 +30,109 @@
         menuHeader.prepend(menuClose);
         nav.prepend(menuHeader);
 
-        menuClose.addEventListener("click", () => {
-          const activeMenuItems =
-            document.querySelectorAll(".menu-item-active");
-          body.classList.remove("mobile-menu-is-active");
-          nav.classList.remove("menu-item-active");
-          topLevelMenu.classList.remove("menu-item-active");
-          menuOpen.setAttribute("aria-expanded", "false");
-
-          if (activeMenuItems) {
-            removeActiveLink(activeMenuItems);
-          }
-        });
-
-        // Create event listener for menu toggle icon.
+        // Menu open links - toggle mobile menu open.
         if (menuOpen) {
           menuOpen.addEventListener("click", () => {
-            const activeMenuItems =
-              document.querySelectorAll(".menu-item-active");
+            this.makeActive([body, nav, topLevelMenu]);
+            this.makeInactive(nav.querySelectorAll(".menu-item-active"));
+            menuOpen.setAttribute("aria-expanded", "true");
+
+            // Set keyboard focus on the first link of the opened menu.
             const firstLink = topLevelMenu.querySelector(
               ".menu-level-0 > li > a"
             );
-
-            body.classList.add("mobile-menu-is-active");
-            nav.classList.add("menu-item-active");
-            topLevelMenu.classList.add("menu-item-active");
-            menuOpen.setAttribute("aria-expanded", "true");
             firstLink.focus();
-
-            // Remove active class on any submenus when the menu is toggled.
-            if (activeMenuItems) {
-              removeActiveLink(activeMenuItems);
-            }
           });
         }
+
+        // Menu close links - toggle mobile menu closed.
+        menuClose.addEventListener("click", () => {
+          this.makeInactive([body, nav, topLevelMenu]);
+          this.makeInactive(nav.querySelectorAll(".menu-item-active"));
+          menuOpen.setAttribute("aria-expanded", "false");
+        });
+
+        // Close the mobile menu when moving up to lg breakpoint.
+        mediaQueryCheck(window.mediaQuery.lg, () => {
+          menuClose.click();
+        }, () => {});
 
         // Clear any active menus when clicking outside of the navigation.
         document.addEventListener("mouseup", (e) => {
           if (!nav.contains(e.target)) {
-            const activeMenuItems =
-              context.querySelectorAll(".menu-item-active");
-            if (activeMenuItems) {
-              removeActiveLink(activeMenuItems);
-            }
+            this.makeInactive(context.querySelectorAll(".menu-item-active"));
           }
         });
-      }
+      });
+
+      // Setup event listeners for the "go back" links shown in mobile menu.
+      once("backLinks", ".back-link a", context).forEach((backLink) => {
+        const parentWrapper = backLink.closest(".submenu-wrapper");
+        const parentMenuLink = parentWrapper.previousElementSibling;
+
+        backLink.addEventListener("click", (event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          this.makeInactive([parentWrapper, parentMenuLink]);
+        });
+      });
+
+      // Setup event listener to toggle the submenu associated with clicking a menu link.
+      once("submenuLinks", ".navigation li.has-submenu > a, .navigation li.has-submenu > span", context).forEach((link) => {
+        const siblingEl = link.nextElementSibling;
+        const parentEl = link.closest("ul");
+
+        link.addEventListener("click", (event) => {
+          event.preventDefault();
+
+          if (!link.classList.contains("menu-item-active")) {
+            // Remove active state from previously selected links.
+            this.makeInactive(parentEl.querySelectorAll(".menu-item-active"));
+
+            this.makeActive([link, siblingEl]);
+          } else {
+            this.makeInactive([link, siblingEl]);
+          }
+        });
+      });
+    },
+
+    // Function to add the active state to an element.
+    makeActive(els) {
+      Array.prototype.forEach.call(els, (el) => {
+        if (el.tagName === 'BODY') {
+          el.classList.add("mobile-menu-is-active");
+        }
+        else {
+          el.classList.add("menu-item-active");
+          if (
+            el.tagName === "A" &&
+            el.hasAttribute("aria-expanded") &&
+            el.getAttribute("aria-expanded") === "false"
+          ) {
+            el.setAttribute("aria-expanded", "true");
+          }
+        }
+      });
+    },
+
+    // Function to remove the active state from an element.
+    makeInactive(els) {
+      Array.prototype.forEach.call(els, (el) => {
+        if (el.tagName === 'BODY') {
+          el.classList.remove("mobile-menu-is-active");
+        }
+        else {
+          el.classList.remove("menu-item-active");
+          if (
+            el.tagName === "A" &&
+            el.hasAttribute("aria-expanded") &&
+            el.getAttribute("aria-expanded") === "true"
+          ) {
+            el.setAttribute("aria-expanded", "false");
+          }
+        }
+      });
     },
   };
-})(Drupal);
+})(Drupal, once);

--- a/themes/wilson_theme_starterkit/src/js/components/main-menu.js
+++ b/themes/wilson_theme_starterkit/src/js/components/main-menu.js
@@ -8,6 +8,7 @@
   let nav;
   let menuOpen;
   let menuClose;
+  let mobileMenuIsOpen = false;
 
   /**
    * Attaches the main menu behaviour.
@@ -27,28 +28,41 @@
         menuOpen = document.querySelector(".menu-open");
         menuClose = nav.querySelector(".menu-close");
 
-        // Menu open links - toggle mobile menu open.
+        // Menu open links - toggle mobile menu overlay.
         if (menuOpen) {
           menuOpen.addEventListener("click", () => {
-            this.openMenuOverlay();
+            if (mobileMenuIsOpen) {
+              this.closeMenuOverlay();
+            }
+            else {
+              this.openMenuOverlay();
+            }
           });
         }
 
         // Menu close links - toggle mobile menu closed.
         if (menuClose) {
           menuClose.addEventListener("click", () => {
-            this.closeMenuOverlay();
+            if (mobileMenuIsOpen) {
+              this.closeMenuOverlay();
+            }
           });
         }
 
-        // Close the mobile menu when moving up to lg breakpoint.
-        mediaQueryCheck(window.mediaQuery.lg, () => {
-          this.closeMenuOverlay();
+        // Close the mobile menu when moving in to the 'lg' breakpoint.
+        // This uses the mediaQueryCheck() facility which fires an event when moving in
+        // and out of a given breakpoint. See media-query-check.js.
+        mediaQueryCheck(window.mediaQuery.md, () => {
+          if (mobileMenuIsOpen) {
+            this.closeMenuOverlay();
+          }
         }, () => {});
 
-        // Clear any active menus when clicking outside of the navigation.
+        // Clear any active menus when clicking anywhere outside of the navigation.
+        // We use closeMenuOverlay() for this, which is a multipurpose function that
+        // closes the mobile and desktop overlays.
         document.addEventListener("mouseup", (e) => {
-          if (!nav.contains(e.target)) {
+          if (!nav.contains(e.target) && !menuOpen.contains(e.target)) {
             this.closeMenuOverlay();
           }
         });
@@ -67,38 +81,42 @@
 
     // Function to open the mobile menu overlay.
     openMenuOverlay() {
+      mobileMenuIsOpen = true;
       const body = document.querySelector("body");
       const topLevelMenu = nav.querySelector(".menu");
-      this.makeActive([body, nav, topLevelMenu]);
-      this.makeInactive(nav.querySelectorAll(".menu-item-active"));
-      menuOpen.setAttribute("aria-expanded", "true");
+      this.makeActive([body, nav, topLevelMenu, menuOpen]);
+
+      // Reset to the top level of the menu by closing any previously opened submenus.
+      this.makeInactive(nav.querySelectorAll(".is-active"));
 
       // Set keyboard focus on the first link of the opened menu.
       const firstLink = topLevelMenu.querySelector(
         ".menu-level-0 > li > a"
       );
-      firstLink.focus();
+      if (firstLink) {
+        firstLink.focus();
+      }
     },
 
     // Function to close the mobile menu overlay.
     closeMenuOverlay() {
+      mobileMenuIsOpen = false;
       const body = document.querySelector("body");
       const topLevelMenu = nav.querySelector(".menu");
-      this.makeInactive([body, nav, topLevelMenu]);
-      this.makeInactive(nav.querySelectorAll(".menu-item-active"));
-      menuOpen.setAttribute("aria-expanded", "false");
+      this.makeInactive([body, nav, topLevelMenu, menuOpen]);
+      this.makeInactive(nav.querySelectorAll(".is-active"));
     },
 
     // Function to add the active state to an element.
     makeActive(els) {
       Array.prototype.forEach.call(els, (el) => {
         if (el.tagName === 'BODY') {
-          el.classList.add("mobile-menu-is-active");
+          el.classList.add("with-menu-overlay");
         }
         else {
-          el.classList.add("menu-item-active");
+          el.classList.add("is-active");
           if (
-            el.tagName === "A" &&
+            (el.tagName === "A" || el.tagName === "BUTTON") &&
             el.hasAttribute("aria-expanded") &&
             el.getAttribute("aria-expanded") === "false"
           ) {
@@ -112,12 +130,12 @@
     makeInactive(els) {
       Array.prototype.forEach.call(els, (el) => {
         if (el.tagName === 'BODY') {
-          el.classList.remove("mobile-menu-is-active");
+          el.classList.remove("with-menu-overlay");
         }
         else {
-          el.classList.remove("menu-item-active");
+          el.classList.remove("is-active");
           if (
-            el.tagName === "A" &&
+            (el.tagName === "A" || el.tagName === "BUTTON") &&
             el.hasAttribute("aria-expanded") &&
             el.getAttribute("aria-expanded") === "true"
           ) {
@@ -135,9 +153,9 @@
       link.addEventListener("click", (event) => {
         event.preventDefault();
 
-        if (!link.classList.contains("menu-item-active")) {
+        if (!link.classList.contains("is-active")) {
           // Remove active state from previously selected links.
-          this.makeInactive(parentEl.querySelectorAll(".menu-item-active"));
+          this.makeInactive(parentEl.querySelectorAll(".is-active"));
 
           this.makeActive([link, siblingEl]);
         } else {

--- a/themes/wilson_theme_starterkit/src/scss/js-components/main-menu.scss
+++ b/themes/wilson_theme_starterkit/src/scss/js-components/main-menu.scss
@@ -1,6 +1,79 @@
 // Styling for the desktop and mobile variants of the main menu.
-// See also main-menu.js.
-.navigation {
+// See also main-menu.js, menu--main.html.twig, and block--menu-block--main.html.twig.
+
+.main-menu {
+  @apply fixed;
+  @apply h-screen;
+  @apply inset-x-0;
+  @apply top-0;
+  @apply bg-secondary;
+  @apply pt-0;
+  @apply pb-4;
+  @apply overflow-hidden;
+  @apply z-[100];
+
+  transform: translateX(100%);
+  transition: 450ms transform cubic-bezier(0.23, 1, 0.32, 1), 450ms box-shadow linear, 450ms visibility linear;
+
+  @screen lg {
+    @apply h-auto;
+    @apply relative;
+    @apply py-0;
+    @apply overflow-visible;
+    @apply bg-transparent;
+    @apply z-auto;
+
+    transform: none;
+    transition: none;
+  }
+
+  &.menu-item-active {
+    @apply visible;
+
+    transform: translateX(0);
+
+    .menu,
+    .menu-close {
+      @apply visible;
+    }
+  }
+
+  &__wrapper {
+    @apply overflow-y-auto;
+    @apply fixed;
+    @apply w-full;
+    @apply inset-0;
+    @apply pb-8;
+
+    @screen lg {
+      @apply overflow-y-visible;
+      @apply relative;
+      @apply h-auto;
+      @apply pb-0;
+      @apply flex;
+    }
+  }
+
+  &__mobile-header {
+    @apply flex;
+    @apply justify-between;
+    @apply items-center;
+    @apply py-3;
+    @apply px-5;
+    @apply border-b;
+    @apply border-secondary-light;
+
+    @screen lg {
+      @apply hidden;
+    }
+  }
+
+  .menu-close {
+    @apply invisible;
+    @apply text-sm;
+    @apply ml-auto;
+  }
+
   ul {
     @apply p-0;
     @apply list-none;
@@ -16,12 +89,6 @@
         @apply border-b-0;
       }
     }
-  }
-
-  .menu-close {
-    @apply invisible;
-    @apply text-sm;
-    @apply ml-auto;
   }
 
   .back-link {
@@ -90,78 +157,6 @@
       @screen lg {
         @apply p-0;
       }
-    }
-  }
-
-  nav {
-    @apply fixed;
-    @apply h-screen;
-    @apply inset-x-0;
-    @apply top-0;
-    @apply bg-secondary;
-    @apply pt-0;
-    @apply pb-4;
-    @apply overflow-hidden;
-    @apply z-[100];
-
-    transform: translateX(100%);
-    transition: 450ms transform cubic-bezier(0.23, 1, 0.32, 1), 450ms box-shadow linear, 450ms visibility linear;
-
-    @screen lg {
-      @apply h-auto;
-      @apply relative;
-      @apply py-0;
-      @apply overflow-visible;
-      @apply bg-transparent;
-      @apply z-auto;
-
-      transform: none;
-      transition: none;
-    }
-
-    &.menu-item-active {
-      @apply visible;
-
-      transform: translateX(0);
-
-      .menu,
-      .menu-close {
-        @apply visible;
-      }
-    }
-  }
-
-  .navigation-wrapper {
-    @apply overflow-y-auto;
-    @apply fixed;
-    @apply w-full;
-    @apply left-0;
-    @apply right-0;
-    @apply bottom-0;
-    @apply pb-8;
-
-    height: calc(100vh - 69px);
-
-    @screen lg {
-      @apply overflow-y-visible;
-      @apply relative;
-      @apply h-auto;
-      @apply pb-0;
-      @apply flex;
-    }
-  }
-
-  .mobile-header {
-    @apply flex;
-    @apply justify-between;
-    @apply items-center;
-    @apply py-3;
-    @apply px-5;
-    @apply border-b;
-    @apply border-secondary-light;
-
-    @screen lg {
-      @apply hidden;
     }
   }
 
@@ -316,6 +311,7 @@
     &.menu-item-active {
       @apply visible;
       @apply left-0;
+      @apply z-1;
     }
   }
 
@@ -419,7 +415,8 @@
       }
 
       &.has-submenu {
-        > a {
+        > a,
+        > span {
           @screen lg {
             @apply hidden;
           }
@@ -469,7 +466,8 @@
           @apply pt-0;
         }
 
-        > a {
+        > a,
+        > span {
           @screen lg {
             @apply text-xl;
           }

--- a/themes/wilson_theme_starterkit/src/scss/js-components/main-menu.scss
+++ b/themes/wilson_theme_starterkit/src/scss/js-components/main-menu.scss
@@ -1,3 +1,5 @@
+// Styling for the desktop and mobile variants of the main menu.
+// See also main-menu.js.
 .navigation {
   ul {
     @apply p-0;
@@ -100,8 +102,8 @@
     @apply pt-0;
     @apply pb-4;
     @apply overflow-hidden;
+    @apply z-[100];
 
-    z-index: 20;
     transform: translateX(100%);
     transition: 450ms transform cubic-bezier(0.23, 1, 0.32, 1), 450ms box-shadow linear, 450ms visibility linear;
 
@@ -111,6 +113,7 @@
       @apply py-0;
       @apply overflow-visible;
       @apply bg-transparent;
+      @apply z-auto;
 
       transform: none;
       transition: none;
@@ -363,6 +366,7 @@
           @apply box-content;
           @apply overflow-y-auto;
           @apply shadow-xl;
+          @apply top-[60px];
 
           top: 60px;
           max-height: calc(100vh - 60px - 100px);
@@ -370,8 +374,8 @@
           -ms-overflow-style: none;  /* IE 10+ */
 
           &::-webkit-scrollbar {
-            width: 0;
-            background: transparent; /* Chrome/Safari/Webkit */
+            @apply w-0;
+            @apply bg-transparent;
           }
         }
 
@@ -411,6 +415,14 @@
       &.parent-link {
         @screen lg {
           @apply w-full;
+        }
+      }
+
+      &.has-submenu {
+        > a {
+          @screen lg {
+            @apply hidden;
+          }
         }
       }
     }
@@ -454,7 +466,19 @@
 
       &.parent-link {
         @screen lg {
-          @apply hidden;
+          @apply pt-0;
+        }
+
+        > a {
+          @screen lg {
+            @apply text-xl;
+          }
+
+          &::after {
+            @screen lg {
+              @apply hidden;
+            }
+          }
         }
       }
 
@@ -465,5 +489,14 @@
         }
       }
     }
+  }
+}
+
+// Prevent scrolling the page when the mobile menu overlay is open.
+body.mobile-menu-is-active {
+  @apply overflow-hidden;
+
+  @screen lg {
+    @apply overflow-auto;
   }
 }

--- a/themes/wilson_theme_starterkit/src/scss/js-components/main-menu.scss
+++ b/themes/wilson_theme_starterkit/src/scss/js-components/main-menu.scss
@@ -5,12 +5,15 @@
   @apply fixed;
   @apply h-screen;
   @apply inset-x-0;
-  @apply top-0;
   @apply bg-secondary;
   @apply pt-0;
   @apply pb-4;
   @apply overflow-hidden;
   @apply z-[100];
+
+  // Offset the menu by the height of the mobile header.
+  // Adjust this as necessary to accommodate site branding.
+  @apply top-[65px];
 
   transform: translateX(100%);
   transition: 450ms transform cubic-bezier(0.23, 1, 0.32, 1), 450ms box-shadow linear, 450ms visibility linear;
@@ -22,12 +25,13 @@
     @apply overflow-visible;
     @apply bg-transparent;
     @apply z-auto;
+    @apply top-auto;
 
     transform: none;
     transition: none;
   }
 
-  &.menu-item-active {
+  &.is-active {
     @apply visible;
 
     transform: translateX(0);
@@ -54,10 +58,8 @@
     }
   }
 
+  /*
   &__mobile-header {
-    @apply flex;
-    @apply justify-between;
-    @apply items-center;
     @apply py-3;
     @apply px-5;
     @apply border-b;
@@ -73,6 +75,7 @@
     @apply text-sm;
     @apply ml-auto;
   }
+  */
 
   ul {
     @apply p-0;
@@ -308,7 +311,7 @@
       }
     }
 
-    &.menu-item-active {
+    &.is-active {
       @apply visible;
       @apply left-0;
       @apply z-1;
@@ -337,16 +340,13 @@
           }
         }
 
-        &.menu-item-active {
+        &.is-active {
           &::after {
             @screen lg {
               @apply rotate-180;
             }
           }
-        }
 
-        &.menu-item-active,
-        &.is-active {
           @screen lg {
             @apply text-primary;
           }
@@ -490,8 +490,62 @@
   }
 }
 
+// Animated hamburger icon.
+// Transforms in to a X icon when '.is-active' class is applied.
+.animated-hamburger {
+  @apply w-8;
+  @apply h-6;
+  @apply relative;
+  @apply cursor-pointer;
+  @apply rotate-0;
+
+  span {
+    @apply block;
+    @apply absolute;
+    @apply left-0;
+    @apply h-1;
+    @apply w-full;
+    @apply bg-current;
+    @apply rounded-[1px];
+    @apply opacity-100;
+    @apply rotate-0;
+    @apply ease-in-out;
+    @apply duration-300;
+
+    &:nth-child(1) {
+      @apply top-0;
+    }
+
+    &:nth-child(2),
+    &:nth-child(3) {
+      @apply top-2.5;
+    }
+
+    &:nth-child(4) {
+      @apply top-5;
+    }
+  }
+
+  &.is-active {
+    span:nth-child(1),
+    span:nth-child(4) {
+      @apply top-2.5;
+      @apply left-1/2;
+      @apply w-0;
+    }
+
+    span:nth-child(2) {
+      @apply rotate-45;
+    }
+
+    span:nth-child(3) {
+      @apply -rotate-45;
+    }
+  }
+}
+
 // Prevent scrolling the page when the mobile menu overlay is open.
-body.mobile-menu-is-active {
+body.with-menu-overlay {
   @apply overflow-hidden;
 
   @screen lg {

--- a/themes/wilson_theme_starterkit/src/scss/js-components/main-menu.scss
+++ b/themes/wilson_theme_starterkit/src/scss/js-components/main-menu.scss
@@ -261,6 +261,7 @@
     @apply fixed;
     @apply w-full;
     @apply invisible;
+    @apply top-0;
     @apply right-0;
     @apply bottom-0;
     @apply bg-secondary;

--- a/themes/wilson_theme_starterkit/templates/block/block--menu-block--main.html.twig
+++ b/themes/wilson_theme_starterkit/templates/block/block--menu-block--main.html.twig
@@ -36,19 +36,6 @@
 {% set heading_id = attributes.id ~ '-menu'|clean_id %}
 <nav role="navigation" aria-labelledby="{{ heading_id }}"{{ attributes.addClass('main-menu')|without('role', 'aria-labelledby') }}>
   <div class="main-menu__wrapper">
-    {# Label. If not displayed, we still provide it for screen readers. #}
-    {% if not configuration.label_display %}
-      {% set title_attributes = title_attributes.addClass('visually-hidden') %}
-    {% endif %}
-
-    {{ title_prefix }}
-    <h2{{ title_attributes.setAttribute('id', heading_id) }}>{{ configuration.label }}</h2>
-    {{ title_suffix }}
-
-    <div class="main-menu__mobile-header">
-      <button class="menu-close btn btn--secondary">{{ 'Close'|t }}</button>
-    </div>
-
     {# Menu. #}
     {% block content %}
       {{ content }}

--- a/themes/wilson_theme_starterkit/templates/block/block--menu-block--main.html.twig
+++ b/themes/wilson_theme_starterkit/templates/block/block--menu-block--main.html.twig
@@ -34,8 +34,8 @@
 {{ attach_library('wilson_theme_starterkit/main-menu') }}
 
 {% set heading_id = attributes.id ~ '-menu'|clean_id %}
-<nav role="navigation" aria-labelledby="{{ heading_id }}"{{ attributes|without('role', 'aria-labelledby') }}>
-  <div class="navigation-wrapper">
+<nav role="navigation" aria-labelledby="{{ heading_id }}"{{ attributes.addClass('main-menu')|without('role', 'aria-labelledby') }}>
+  <div class="main-menu__wrapper">
     {# Label. If not displayed, we still provide it for screen readers. #}
     {% if not configuration.label_display %}
       {% set title_attributes = title_attributes.addClass('visually-hidden') %}
@@ -44,6 +44,10 @@
     {{ title_prefix }}
     <h2{{ title_attributes.setAttribute('id', heading_id) }}>{{ configuration.label }}</h2>
     {{ title_suffix }}
+
+    <div class="main-menu__mobile-header">
+      <button class="menu-close btn btn--secondary">{{ 'Close'|t }}</button>
+    </div>
 
     {# Menu. #}
     {% block content %}

--- a/themes/wilson_theme_starterkit/templates/layout/page.html.twig
+++ b/themes/wilson_theme_starterkit/templates/layout/page.html.twig
@@ -52,7 +52,7 @@
 </header>
 
 {% if page.header_navigation %}
-  <div class="navigation bg-secondary text-secondary-contrast z-20">
+  <div class="bg-secondary text-secondary-contrast z-20">
     {{ page.header_navigation }}
   </div>
 {% endif %}

--- a/themes/wilson_theme_starterkit/templates/layout/region--header-links.html.twig
+++ b/themes/wilson_theme_starterkit/templates/layout/region--header-links.html.twig
@@ -16,6 +16,12 @@
   <div class="container mx-auto px-5 flex justify-between items-center">
     {{ content }}
 
-    <button class="menu-open btn btn--secondary text-sm ml-4 lg:hidden" aria-expanded="false" aria-label="{{ 'Open the menu'|t }}">{{ 'Menu'|t }}</button>
+    {# Toggle button for opening mobile menu. See main-menu.js and main-menu.scss. #}
+    <button class="menu-open w-10 ml-4 lg:hidden animated-hamburger" aria-expanded="false" aria-label="{{ 'Toggle the menu'|t }}">
+      <span></span>
+      <span></span>
+      <span></span>
+      <span></span>
+    </button>
   </div>
 {% endif %}

--- a/themes/wilson_theme_starterkit/wilson_theme_starterkit.libraries.yml
+++ b/themes/wilson_theme_starterkit/wilson_theme_starterkit.libraries.yml
@@ -90,6 +90,7 @@ main-menu:
     dist/js/components/main-menu.js: { minified: true }
   dependencies:
     - core/drupal
+    - core/once
     - wilson_theme_starterkit/global
 
 background-videos:


### PR DESCRIPTION
While updating the Wilson demo site, I discovered that the main menu javascript was very broken, and stupidly complex. This PR refactors the JS and styling for the main menu to fix the issues I spotted.

I rewrote the JS to use use Drupal `once` so that click events wouldn't be fired twice, which was the main reason why the menus weren't opening correctly. I also reduced some complexity by making `makeActive` and `makeInactive` functions that help reduce repeated code.

@ismael-abujadur I'm raising this PR against Wilson, but I'd strongly recommend you copy the updated files in to your custom WaterUK theme before you get too far along with the customisation.