### PR TITLE
Remove erroneous ctools replacement in Wilson composer file in 1.x branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,8 +56,5 @@
         "drupal/viewsreference": "^2.0@beta",
         "drupal/webform": "^6.0",
         "drupal/webp": "^1.0@beta"
-    },
-    "replace": {
-        "drupal/ctools": "*"
     }
 }


### PR DESCRIPTION
I misunderstood the instructions in the latest version of Pathauto and had added this replacement to Wilson's composer file. Andrew set me straight and this is now being removed to allow Wilson-powered projects to use CTools if they so wish.

This is the same as https://github.com/accessdigital/wilson/pull/47 but for 1.x branch.